### PR TITLE
Make it so that Claude only comments when tagged

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,8 +1,8 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize]
+  issue_comment:
+    types: [created]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -17,19 +17,52 @@ jobs:
     #   github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '@claude')
     
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
     
     steps:
-      - name: Checkout repository
+      - name: Checkout PR Branch
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          ref: refs/pull/${{ github.event.issue.number }}/head
+          fetch-depth: 0 # full clone to get all commits, not just most recent
+
+      - name: Prepare Prompt
+        id: prepare_prompt
+        # Get the comment body (remove '@claude' mention),
+        # Build default prompt,
+        # Combine it with the user-provided specific prompt (if it exists),
+        # Feed Claude that prompt
+
+        run: |
+          PROMPT_TEXT=$(echo "${{ github.event.comment.body }}" | sed -E 's/@claude//i' | xargs)
+          
+          DEFAULT_PROMPT="In addition to any instructions above, please review this pull request for the following:
+          - Code quality and best practices
+          - Potential bugs or issues
+          - Performance considerations
+          - Security concerns
+          - Test coverage
+          
+          Be constructive and helpful in your feedback."
+          
+          if [[ -n "$PROMPT_TEXT" ]]; then
+            FINAL_PROMPT=$(printf "%s\n\n%s" "$PROMPT_TEXT" "$DEFAULT_PROMPT")
+          else
+            FINAL_PROMPT="$DEFAULT_PROMPT"
+          fi
+          
+          echo "prompt<<EOF" >> $GITHUB_OUTPUT
+          echo "$FINAL_PROMPT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+
 
       - name: Run Claude Code Review
         id: claude-review
@@ -41,15 +74,7 @@ jobs:
           # model: "claude-opus-4-1-20250805"
 
           # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
-            
-            Be constructive and helpful in your feedback.
+          direct_prompt: ${{ steps.prepare_prompt.outputs.prompt }}
 
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           # use_sticky_comment: true


### PR DESCRIPTION
Change Claude workflow config file so that it only chimes in when you tag it with `@cl**de` (not spelling it out such that it doesn't comment without my permission yet haha). Features of this:

- Had to give Claude `write` permission on PR to make this work (because there are now more restrictions on its github access token)
- Switched history fetching from depth of `1` to a depth of `0` (which is a full commit history clone, not just most recent commit). If it's too labor intensive for Claude we can change it
- The default prompt is still what it was before, but now if you include more info in your Claude tag, it will add that to the prompt. E.g.:
```
@cl**de, how does the formatting look in ForecastViz.jsx
```
It will give Claude that prompt + the default. I can change this too if it's messy