### PR TITLE
URL Polishing

### DIFF
--- a/app/src/components/DataVisualization.jsx
+++ b/app/src/components/DataVisualization.jsx
@@ -98,7 +98,7 @@ const DataVisualization = ({
   // Render appropriate view based on viewType
   switch (viewType) {
     case 'fludetailed':
-    case 'flutimeseries':
+    case 'flu_ts':
       return (
         <FluView
           data={data}
@@ -112,7 +112,7 @@ const DataVisualization = ({
         />
       );
 
-    case 'rsvdetailed':
+    case 'rsv_ts':
       return (
         <RSVDefaultView
           location={location}
@@ -126,7 +126,7 @@ const DataVisualization = ({
         />
       );
 
-    case 'covidtimeseries':
+    case 'covid_ts':
       return(
         <COVID19View
           data={data}

--- a/app/src/config/datasets.js
+++ b/app/src/config/datasets.js
@@ -19,7 +19,7 @@ export const DATASETS = {
     views: [
       { key: 'detailed', label: 'Time Series', value: 'rsv_ts' }
     ],
-    defaultView: 'rsvdetailed',
+    defaultView: 'rsv_ts',
     defaultModel: 'hub-ensemble',
     hasDateSelector: true,
     hasModelSelector: true,
@@ -32,7 +32,7 @@ export const DATASETS = {
     views: [
       { key: 'timeseries', label: 'Time Series', value: 'covid_ts' }
     ],
-    defaultView: 'covidtimeseries',
+    defaultView: 'covid_ts',
     defaultModel: 'COVIDHub-ensemble',
     hasDateSelector: true,
     hasModelSelector: true,

--- a/app/src/config/datasets.js
+++ b/app/src/config/datasets.js
@@ -4,7 +4,7 @@ export const DATASETS = {
     fullName: 'FluSight',
     views: [
       { key: 'detailed', label: 'Detailed View', value: 'fludetailed' },
-      { key: 'timeseries', label: 'Time Series', value: 'flutimeseries' }
+      { key: 'timeseries', label: 'Time Series', value: 'flu_ts' }
     ],
     defaultView: 'fludetailed',
     defaultModel: 'FluSight-ensemble',
@@ -17,7 +17,7 @@ export const DATASETS = {
     shortName: 'rsv',
     fullName: 'RSV Forecast Hub',
     views: [
-      { key: 'detailed', label: 'Detailed View', value: 'rsvdetailed' }
+      { key: 'detailed', label: 'Time Series', value: 'rsv_ts' }
     ],
     defaultView: 'rsvdetailed',
     defaultModel: 'hub-ensemble',
@@ -30,7 +30,7 @@ export const DATASETS = {
     shortName: 'covid',
     fullName: 'COVID-19 Forecast Hub',
     views: [
-      { key: 'timeseries', label: 'Time Series', value: 'covidtimeseries' }
+      { key: 'timeseries', label: 'Time Series', value: 'covid_ts' }
     ],
     defaultView: 'covidtimeseries',
     defaultModel: 'COVIDHub-ensemble',

--- a/app/src/contexts/ViewContext.jsx
+++ b/app/src/contexts/ViewContext.jsx
@@ -50,8 +50,6 @@ export const ViewProvider = ({ children }) => {
       } else if (currentDataset.defaultColumn) {
         const defaultCols = [currentDataset.defaultColumn];
         setSelectedColumns(defaultCols);
-        // We still update the URL here because NHSN has no default view state
-        updateDatasetParams({ columns: defaultCols });
       }
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -125,7 +123,28 @@ export const ViewProvider = ({ children }) => {
       setSelectedModels(models);
     },
     selectedDates, setSelectedDates: (dates) => { setSelectedDates(dates); updateDatasetParams({ dates }); },
-    selectedColumns, setSelectedColumns: (columns) => { setSelectedColumns(columns); updateDatasetParams({ columns }); },
+    selectedColumns, setSelectedColumns: (columns) => { 
+      const currentDataset = urlManager.getDatasetFromView(viewType);
+      
+      if (currentDataset?.shortName === 'nhsn') {
+        const defaultColumn = currentDataset.defaultColumn;
+        // Check if the current selection is the default
+        const isDefault = columns.length === 1 && columns[0] === defaultColumn;
+        
+        if (isDefault) {
+          // If returning to default, REMOVE the parameter from the URL
+          const newParams = new URLSearchParams(searchParams);
+          newParams.delete('nhsn_columns');
+          setSearchParams(newParams, { replace: true });
+        } else {
+          // If it's not the default, UPDATE the URL
+          updateDatasetParams({ columns });
+        }
+      }
+      // Always update the state itself
+      setSelectedColumns(columns);
+    },
+
     activeDate, setActiveDate,
     viewType, setViewType: handleViewChange,
     currentDataset: urlManager.getDatasetFromView(viewType)

--- a/app/src/contexts/ViewContext.jsx
+++ b/app/src/contexts/ViewContext.jsx
@@ -19,65 +19,43 @@ export const ViewProvider = ({ children }) => {
   const [selectedModels, setSelectedModels] = useState([]);
   const [selectedDates, setSelectedDates] = useState([]);
   const [activeDate, setActiveDate] = useState(null);
-  const [selectedColumns, setSelectedColumns] = useState([]); // Add state for NHSN columns
+  const [selectedColumns, setSelectedColumns] = useState([]);
 
   // --- Data fetching remains centralized ---
   const { data, loading, error, availableDates, models } = useForecastData(selectedLocation, viewType);
+  
+  const updateDatasetParams = useCallback((params) => {
+    const currentDataset = urlManager.getDatasetFromView(viewType);
+    if (currentDataset) urlManager.updateDatasetParams(currentDataset, params);
+  }, [viewType, urlManager]);
 
-  // This effect now ONLY runs its logic when we are on the forecast page ('/')
-  useEffect(() => {
-    if (location.pathname === '/') {
-      const currentParams = new URLSearchParams(searchParams);
-      let needsUpdate = false;
-
-      if (!currentParams.has('location')) {
-        currentParams.set('location', 'US');
-        needsUpdate = true;
-      }
-      const view = currentParams.get('view') || 'fludetailed';
-      if (!currentParams.has('view')) {
-        currentParams.set('view', view);
-        needsUpdate = true;
-      }
-      const initialDataset = Object.values(DATASETS).find(d => 
-        d.views.some(v => v.value === view)
-      );
-      if (initialDataset?.defaultModel && !currentParams.has(`${initialDataset.prefix}_models`)) {
-        currentParams.set(`${initialDataset.prefix}_models`, initialDataset.defaultModel);
-        needsUpdate = true;
-      }
-      if (needsUpdate) {
-        setSearchParams(currentParams, { replace: true });
-      }
-    }
-  }, [location.pathname]);
-
-  // Effect to initialize models and columns from URL
+  // Effect to initialize models and columns from URL, with defaults for a clean URL
   useEffect(() => {
     const currentDataset = urlManager.getDatasetFromView(viewType);
     if (!currentDataset) return;
 
     const params = urlManager.getDatasetParams(currentDataset);
+    
+    // Set models: use URL params if they exist, otherwise use the dataset's default model
     if (params.models?.length > 0) {
       setSelectedModels(params.models);
+    } else if (currentDataset.defaultModel) {
+      setSelectedModels([currentDataset.defaultModel]);
     }
-    
-    // Initialize columns for NHSN view
+
+    // Set columns for NHSN view
     if (currentDataset.shortName === 'nhsn') {
       if (params.columns?.length > 0) {
         setSelectedColumns(params.columns);
-      } else {
-        if (currentDataset.defaultColumn) {
-          // Set a default if nothing is in the URL
-          const defaultCols = [currentDataset.defaultColumn];
-          setSelectedColumns(defaultCols);
-          updateDatasetParams({ columns: defaultCols });
-        }
-
+      } else if (currentDataset.defaultColumn) {
+        const defaultCols = [currentDataset.defaultColumn];
+        setSelectedColumns(defaultCols);
+        // We still update the URL here because NHSN has no default view state
+        updateDatasetParams({ columns: defaultCols });
       }
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams, viewType]);
-
 
   useEffect(() => {
     if (!loading && availableDates.length > 0 && selectedDates.length === 0) {
@@ -90,8 +68,16 @@ export const ViewProvider = ({ children }) => {
   }, [loading, availableDates]);
 
   const handleLocationSelect = (newLocation) => {
+    // Only update URL if the location is not the default
+    if (newLocation !== 'US') {
+      urlManager.updateLocation(newLocation);
+    } else {
+      // If returning to default, remove it from URL
+      const newParams = new URLSearchParams(searchParams);
+      newParams.delete('location');
+      setSearchParams(newParams, { replace: true });
+    }
     setSelectedLocation(newLocation);
-    urlManager.updateLocation(newLocation);
   };
   
   const handleViewChange = useCallback((newView) => {
@@ -101,40 +87,44 @@ export const ViewProvider = ({ children }) => {
     const oldDataset = urlManager.getDatasetFromView(oldView);
     const newDataset = urlManager.getDatasetFromView(newView);
     const newSearchParams = new URLSearchParams(searchParams);
-    newSearchParams.set('view', newView);
+
+    // Set the view in the URL, unless it's the default view with no other params
+    if (newView !== 'fludetailed' || newSearchParams.toString().length > 0) {
+      newSearchParams.set('view', newView);
+    } else {
+      newSearchParams.delete('view');
+    }
 
     if (oldDataset?.shortName !== newDataset?.shortName) {
       setSelectedDates([]);
       setSelectedModels([]);
-      setSelectedColumns([]); // Reset columns state
+      setSelectedColumns([]);
       setActiveDate(null);
       if (oldDataset) {
         newSearchParams.delete(`${oldDataset.prefix}_models`);
         newSearchParams.delete(`${oldDataset.prefix}_dates`);
-        // **THE FIX**: Explicitly delete NHSN columns when leaving the NHSN view
         if (oldDataset.shortName === 'nhsn') {
           newSearchParams.delete('nhsn_columns');
         }
       }
-      if (newDataset?.defaultModel) {
-        newSearchParams.set(`${newDataset.prefix}_models`, newDataset.defaultModel);
-      }
+      // Do not set default model in URL on view change
     }
     setViewType(newView);
-    setSearchParams(newSearchParams);
+    setSearchParams(newSearchParams, { replace: true });
   }, [viewType, searchParams, setSearchParams, urlManager]);
-
-  const updateDatasetParams = useCallback((params) => {
-    const currentDataset = urlManager.getDatasetFromView(viewType);
-    if (currentDataset) urlManager.updateDatasetParams(currentDataset, params);
-  }, [viewType, urlManager]);
 
   const contextValue = {
     selectedLocation, handleLocationSelect,
     data, loading, error, availableDates, models,
-    selectedModels, setSelectedModels: (models) => { setSelectedModels(models); updateDatasetParams({ models }); },
+    selectedModels, setSelectedModels: (models) => { 
+      const currentDataset = urlManager.getDatasetFromView(viewType);
+      // Only update URL if models are not the default
+      if (JSON.stringify(models) !== JSON.stringify([currentDataset?.defaultModel])) {
+        updateDatasetParams({ models }); 
+      }
+      setSelectedModels(models);
+    },
     selectedDates, setSelectedDates: (dates) => { setSelectedDates(dates); updateDatasetParams({ dates }); },
-    // Expose column state and its updater function
     selectedColumns, setSelectedColumns: (columns) => { setSelectedColumns(columns); updateDatasetParams({ columns }); },
     activeDate, setActiveDate,
     viewType, setViewType: handleViewChange,

--- a/app/src/hooks/useForecastData.js
+++ b/app/src/hooks/useForecastData.js
@@ -19,9 +19,9 @@ export const useForecastData = (location, viewType) => {
         // Determine the data path based on view type
         const datasetMap = {
           'fludetailed': 'flusight',
-          'flutimeseries': 'flusight', 
-          'covidtimeseries': 'covid19',
-          'rsvdetailed': 'rsv',
+          'flu_ts': 'flusight', 
+          'covid_ts': 'covid19',
+          'rsv_ts': 'rsv',
           'nhsnall': 'nhsn'
         };
 


### PR DESCRIPTION
- Make timeseries URL parameters say `_ts` instead of `timeseries`
- Make default URL params invisible until non-default is selected 
- Rename 'RSV Detailed View' -> 'RSV Time Series' because RSV hub data does not have the categorical data necessary for the detailed view 
