### PR TITLE
Fix default covid hub typo

### DIFF
--- a/app/src/config/datasets.js
+++ b/app/src/config/datasets.js
@@ -33,7 +33,7 @@ export const DATASETS = {
       { key: 'timeseries', label: 'Time Series', value: 'covid_ts' }
     ],
     defaultView: 'covid_ts',
-    defaultModel: 'COVIDHub-ensemble',
+    defaultModel: 'CovidHub-ensemble',
     hasDateSelector: true,
     hasModelSelector: true,
     prefix: 'covid',


### PR DESCRIPTION
in `datasets.js` the default model for covid view was `COVIDHub-ensemble` and it should have been `CovidHub-ensemble`. I fixed that here and it seems like it displays correctly now. 