### PR TITLE
Updates

### DIFF
--- a/app/src/components/ForecastPlotView.jsx
+++ b/app/src/components/ForecastPlotView.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from "react";
-import { useMantineColorScheme, Stack, Text } from "@mantine/core";
+import { useMantineColorScheme, Stack, Text, Box, Center } from "@mantine/core";
 import Plot from "react-plotly.js";
 import Plotly from "plotly.js/dist/plotly";
 import ModelSelector from "./ModelSelector";
@@ -359,6 +359,7 @@ const ForecastPlotView = ({
     return baseConfig;
   }, [calculateYRange, configOverrides]);
 
+  const hasForecasts = projectionsData.length > 1;
   if (requireTarget && !selectedTarget) {
     return (
       <Stack align="center" justify="center" style={{ height: "300px" }}>
@@ -374,12 +375,40 @@ const ForecastPlotView = ({
         timestamp={metadata?.last_updated}
       />
       <div
-        style={{ width: "100%", height: "min(800px, 60vh)", minHeight: 320 }}
+        style={{
+          width: "100%",
+          height: "min(800px, 60vh)",
+          minHeight: 320,
+          position: "relative", // Ensure the container is relative for absolute positioning
+        }}
       >
+        {!hasForecasts && (
+          <Box
+            style={{
+              position: "absolute",
+              top: 80, // Adjusted slightly for the larger main view
+              left: 0,
+              right: 0,
+              zIndex: 1,
+              pointerEvents: "none",
+            }}
+          >
+            <Center>
+              <Text size="sm" c="dimmed" fs="italic">
+                No forecast data available for the current selection
+              </Text>
+            </Center>
+          </Box>
+        )}
+
         <Plot
           ref={plotRef}
           useResizeHandler
-          style={{ width: "100%", height: "100%" }}
+          style={{
+            width: "100%",
+            height: "100%",
+            opacity: hasForecasts ? 1 : 0.6, // Dim the plot if no forecasts exist
+          }}
           data={finalTraces}
           layout={layout}
           config={config}

--- a/app/src/components/InfoOverlay.jsx
+++ b/app/src/components/InfoOverlay.jsx
@@ -52,14 +52,15 @@ const InfoOverlay = () => {
         opened={opened}
         onClose={close}
         title={
-          <Group gap="md">
+          <Group gap="sm" wrap="nowrap" align="center">
             <Image
               src="respilens-logo.svg"
               alt="RespiLens logo"
               h={32}
               w={32}
+              fit="contain"
             />
-            <Title order={2} c="blue">
+            <Title order={2} c="blue" style={{ lineHeight: 1 }}>
               RespiLens
             </Title>
           </Group>

--- a/app/src/components/views/NHSNView.jsx
+++ b/app/src/components/views/NHSNView.jsx
@@ -74,6 +74,7 @@ const NHSNView = ({ location }) => {
   const [filteredAvailableColumns, setFilteredAvailableColumns] = useState([]); // Columns for the selected target
 
   const [selectedColumns, setSelectedColumns] = useState([]);
+  const hasInteractedRef = useRef(false);
   const [availableTargets, setAvailableTargets] = useState([]);
   const [selectedTarget, setSelectedTarget] = useState(null); // This is the string key, e.g., "Raw Patient Counts"
 
@@ -195,14 +196,24 @@ const NHSNView = ({ location }) => {
     setFilteredAvailableColumns(filtered);
 
     const urlSlugs = searchParams.getAll("nhsn_cols");
+    const urlTarget = searchParams.get("nhsn_target");
+
+    const isExplicitlyEmpty = urlSlugs.includes("none");
+
     const validUrlCols = urlSlugs
       .map((slug) => nhsnSlugToNameMap[slug])
       .filter((colName) => colName && filtered.includes(colName));
 
     let newSelectedCols;
+
     if (validUrlCols.length > 0) {
       newSelectedCols = validUrlCols;
-    } else if (filtered.length > 0) {
+    } else if (isExplicitlyEmpty) {
+      newSelectedCols = [];
+    } else if (
+      !hasInteractedRef.current ||
+      (urlTarget !== selectedTarget && urlSlugs.length === 0)
+    ) {
       const defaultColumns = getDefaultColumnsForTarget(selectedTarget);
       const filteredDefaults = defaultColumns.filter((col) =>
         filtered.includes(col),
@@ -214,10 +225,11 @@ const NHSNView = ({ location }) => {
     }
 
     setSelectedColumns((currentCols) => {
-      const newSorted = [...newSelectedCols].sort();
-      const currentSorted = [...currentCols].sort();
-      if (JSON.stringify(newSorted) !== JSON.stringify(currentSorted))
+      const sortedNew = [...newSelectedCols].sort();
+      const sortedCurrent = [...currentCols].sort();
+      if (JSON.stringify(sortedNew) !== JSON.stringify(sortedCurrent)) {
         return newSelectedCols;
+      }
       return currentCols;
     });
   }, [loading, selectedTarget, allDataColumns, searchParams]);
@@ -231,18 +243,25 @@ const NHSNView = ({ location }) => {
     ) {
       return;
     }
+
     const currentSearch = window.location.search;
     const newParams = new URLSearchParams(currentSearch);
-    const defaultTarget = availableTargets[0];
-    if (selectedTarget && selectedTarget !== defaultTarget)
-      newParams.set("nhsn_target", selectedTarget);
-    else newParams.delete("nhsn_target");
 
-    const columnsForTarget = nhsnTargetsToColumnsMap[selectedTarget] || [];
-    const filteredCols = allDataColumns.filter((col) =>
-      columnsForTarget.includes(col),
-    );
+    // Target Sync
+    const defaultTarget = availableTargets[0];
+    if (selectedTarget && selectedTarget !== defaultTarget) {
+      newParams.set("nhsn_target", selectedTarget);
+    } else {
+      newParams.delete("nhsn_target");
+    }
+
+    // Column Sync
+    newParams.delete("nhsn_cols");
+
     const defaultColumnsArray = getDefaultColumnsForTarget(selectedTarget);
+    const filteredCols = allDataColumns.filter((col) =>
+      (nhsnTargetsToColumnsMap[selectedTarget] || []).includes(col),
+    );
     const filteredDefaults = defaultColumnsArray.filter((col) =>
       filteredCols.includes(col),
     );
@@ -252,20 +271,22 @@ const NHSNView = ({ location }) => {
         : filteredCols.length > 0
           ? [filteredCols[0]]
           : [];
-    const sortedSelected = [...selectedColumns].sort();
-    const sortedDefault = [...defaultColumns].sort();
-    const selectedSlugs = sortedSelected
-      .map((name) => nhsnNameToSlugMap[name])
-      .filter(Boolean);
-    const defaultSlugs = sortedDefault
-      .map((name) => nhsnNameToSlugMap[name])
-      .filter(Boolean);
-    if (JSON.stringify(selectedSlugs) !== JSON.stringify(defaultSlugs)) {
-      newParams.delete("nhsn_cols");
-      selectedSlugs.forEach((slug) => newParams.append("nhsn_cols", slug));
-    } else {
-      newParams.delete("nhsn_cols");
+
+    const isDefault =
+      JSON.stringify([...selectedColumns].sort()) ===
+      JSON.stringify([...defaultColumns].sort());
+
+    if (!isDefault) {
+      if (selectedColumns.length > 0) {
+        selectedColumns.forEach((name) => {
+          const slug = nhsnNameToSlugMap[name];
+          if (slug) newParams.append("nhsn_cols", slug);
+        });
+      } else if (hasInteractedRef.current) {
+        newParams.set("nhsn_cols", "none");
+      }
     }
+
     if (
       newParams.toString() !== new URLSearchParams(currentSearch).toString()
     ) {
@@ -279,6 +300,11 @@ const NHSNView = ({ location }) => {
     loading,
     setSearchParams,
   ]);
+
+  const handleSetSelectedColumns = useCallback((newCols) => {
+    hasInteractedRef.current = true;
+    setSelectedColumns(newCols);
+  }, []);
 
   useEffect(() => {
     if (data) setPlotRevision((p) => p + 1);
@@ -412,6 +438,17 @@ const NHSNView = ({ location }) => {
 
   const traces = useMemo(() => {
     if (!data) return [];
+    if (selectedColumns.length === 0) {
+      return [
+        {
+          x: [data.series.dates[0]],
+          y: [null],
+          type: "scatter",
+          mode: "lines",
+          showlegend: false,
+        },
+      ];
+    }
 
     return selectedColumns.map((columnName) => {
       const columnIndex = filteredAvailableColumns.indexOf(columnName);
@@ -465,7 +502,10 @@ const NHSNView = ({ location }) => {
       yaxis: {
         title: nhsnYAxisLabelMap[selectedTarget] || "Value",
         range: chartScale === "log" ? undefined : yAxisRange,
-        autorange: chartScale === "log" ? true : yAxisRange === null,
+        autorange:
+          chartScale === "log"
+            ? true
+            : yAxisRange === null || selectedColumns.length === 0,
         type: chartScale === "log" ? "log" : "linear",
         tickmode: chartScale === "sqrt" && sqrtTicks ? "array" : undefined,
         tickvals:
@@ -489,6 +529,21 @@ const NHSNView = ({ location }) => {
       },
       margin: { t: 40, r: 10, l: 60, b: 120 },
       uirevision: plotRevision,
+      annotations:
+        selectedColumns.length === 0
+          ? [
+              {
+                text: "No columns selected",
+                xref: "paper",
+                yref: "paper",
+                showarrow: false,
+                font: {
+                  size: 20,
+                  color: colorScheme === "dark" ? "#5c5f66" : "#adb5bd",
+                },
+              },
+            ]
+          : [],
     }),
     [
       colorScheme,
@@ -602,11 +657,14 @@ const NHSNView = ({ location }) => {
       <NHSNColumnSelector
         availableColumns={filteredAvailableColumns}
         selectedColumns={selectedColumns}
-        setSelectedColumns={setSelectedColumns}
+        setSelectedColumns={handleSetSelectedColumns}
         nameMap={nhsnNameToPrettyNameMap}
         selectedTarget={selectedTarget}
         availableTargets={availableTargets}
-        onTargetChange={setSelectedTarget}
+        onTargetChange={(val) => {
+          hasInteractedRef.current = false;
+          setSelectedTarget(val);
+        }}
         loading={loading}
       />
     </Stack>

--- a/app/src/components/views/NHSNView.jsx
+++ b/app/src/components/views/NHSNView.jsx
@@ -232,7 +232,8 @@ const NHSNView = ({ location }) => {
       }
       return currentCols;
     });
-  }, [loading, selectedTarget, allDataColumns, searchParams]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loading, selectedTarget, allDataColumns]);
 
   useEffect(() => {
     if (

--- a/app/src/hooks/extractPlotDataFromURL.js
+++ b/app/src/hooks/extractPlotDataFromURL.js
@@ -208,7 +208,7 @@ export const extractPlotData = (viewType, href, data) => {
     }
 
     default:
-      throw new Error(`Unknown view type: ${viewType}`); // TODO: handle peak view
+      throw new Error(`Unknown view type: ${viewType}`);
   }
 
   const plotData = {

--- a/app/src/utils/mapUtils.js
+++ b/app/src/utils/mapUtils.js
@@ -135,6 +135,7 @@ export const nhsnTargetsToColumnsMap = {
     "Percent Adult Inpatient Beds Occupied",
     "Percent Pediatric Inpatient Beds Occupied",
     "Percent Adult ICU Beds Occupied",
+    "Percent Pediatric ICU Beds Occupied",
   ],
 };
 
@@ -805,26 +806,38 @@ export const nhsnNameToPrettyNameMap = {
   "Total Adult RSV Admissions": "Adult Admissions",
   "Number of RSV Admissions, unknown age": "Admissions (unknown age)",
   "Total RSV Admissions": "Total Admissions",
-  "Percent Inpatient Beds Occupied": "Inpatient Beds Occupied",
+  "Percent Adult ICU Beds Occupied": "Percent of Adult ICU Beds Occupied",
+  "Percent Pediatric ICU Beds Occupied":
+    "Percent of Pediatric ICU Beds Occupied",
+  "Percent Adult Inpatient Beds Occupied":
+    "Percent of Adult Inpatient Beds Occupied",
+  "Percent Pediatric Inpatient Beds Occupied":
+    "Percent of Pediatric Inpatient Beds Occupied",
+  "Percent Inpatient Beds Occupied": "Percent of Inpatient Beds Occupied",
   "Percent Inpatient Beds Occupied by COVID-19 Patients":
-    "Inpatient Beds Occupied by COVID-19 Patients",
+    "Percent of Inpatient Beds Occupied by COVID-19 Patients",
   "Percent Inpatient Beds Occupied by Influenza Patients":
-    "Inpatient Beds Occupied by Influenza Patients",
+    "Percent of Inpatient Beds Occupied by Influenza Patients",
   "Percent Inpatient Beds Occupied by RSV Patients":
-    "Inpatient Beds Occupied by RSV Patients",
-  "Percent ICU Beds Occupied": "ICU Beds Occupied",
+    "Percent of Inpatient Beds Occupied by RSV Patients",
+  "Percent ICU Beds Occupied": "Percent of ICU Beds Occupied",
   "Percent ICU Beds Occupied by COVID-19 Patients":
-    "ICU Beds Occupied by COVID-19 Patients",
+    "Percent of ICU Beds Occupied by COVID-19 Patients",
   "Percent ICU Beds Occupied by Influenza Patients":
-    "ICU Beds Occupied by Influenza Patients",
+    "Percent of ICU Beds Occupied by Influenza Patients",
   "Percent ICU Beds Occupied by RSV Patients":
-    "ICU Beds Occupied by RSV Patients",
-  "Percent Adult COVID-19 Admissions": "Adult Admissions",
-  "Percent Pediatric COVID-19 Admissions": "Pediatric Admissions",
-  "Percent Adult Influenza Admissions": "Adult Admissions",
-  "Percent Pediatric Influenza Admissions": "Pediatric Admissions",
-  "Percent Adult RSV Admissions": "Adult Admissions",
-  "Percent Pediatric RSV Admissions": "Pediatric Admissions",
+    "Percent of ICU Beds Occupied by RSV Patients",
+  "Percent Adult COVID-19 Admissions":
+    "Percent of COVID-19 Admissions that are Adults",
+  "Percent Pediatric COVID-19 Admissions":
+    "Percent of COVID-19 Admissions that are Pediatric",
+  "Percent Adult Influenza Admissions":
+    "Percent of Influenza Admissions that are Adults",
+  "Percent Pediatric Influenza Admissions":
+    "Percent of Influenza Admissions that are Pediatric",
+  "Percent Adult RSV Admissions": "Percent of RSV Admissions that are Adults",
+  "Percent Pediatric RSV Admissions":
+    "Percent of RSV Admissions that are Pediatric",
   "Number of Pediatric COVID-19 Admissions, 0-4 years, per 100,000 population":
     "Pediatric Admissions (0-4 years)",
   "Number of Pediatric COVID-19 Admissions, 5-17 years, per 100,000 population":


### PR DESCRIPTION
- Add nice "no forecasts available" message to flu, rsv, covid views (was just on metrocast view before)
- Fixes a bug that was on staging relating to infinite reload in NHSN view when you switch locations with more than default columns selected (requires removal of `searchParams` dep from a `useEffect()`, and ignoring this "missing" dep with an eslint step-over)
- Fixes a persistent main-level bug where the NHSN view breaks if you manually de-select all columns
    - now you can have no columns selected with a message that says "you have no columns selected"
- Fixes the logo in the RespiLens info overlay (which was cut off before)
- Renames a handful of NHSN columns (on the user side) to more intuitively describe what they represent 