### PR TITLE
add emily test tournament

### DIFF
--- a/app/.env
+++ b/app/.env
@@ -1,4 +1,5 @@
 # Tournament API Configuration
 # Replace with your deployed Google Apps Script Web App URL
 # See TOURNAMENT_SETUP.md for deployment instructions
-VITE_TOURNAMENT_API_URL=https://script.google.com/macros/s/AKfycbwB7LnE8DSk9S7ACLs20j65iB-9ryCXAiih2FlMwpeWDDE4pLZ1zF3RQilfrm6_byLU7w/exec
+VITE_EMILY_TOURNAMENT_API_URL=https://script.google.com/macros/s/AKfycby_pE9-KoA_bWjv9xIzNC1DF8jIrMPbQJ3I9P62RafivdQaHujnX2539tYFZtrn-nGRpw/exec
+VITE_EPIDEMICS10_TOURNAMENT_API_URL=https://script.google.com/macros/s/AKfycbwB7LnE8DSk9S7ACLs20j65iB-9ryCXAiih2FlMwpeWDDE4pLZ1zF3RQilfrm6_byLU7w/exec

--- a/app/src/config/tournament.js
+++ b/app/src/config/tournament.js
@@ -65,8 +65,7 @@ export const TOURNAMENT_REGISTRY = [
     name: "Toy tournament created by Emily",
     description:
       "Compete in 3 epidemic forecasting challenges and climb the leaderboard",
-    // apiUrl: "https://script.google.com/macros/s/AKfycby_pE9-KoA_bWjv9xIzNC1DF8jIrMPbQJ3I9P62RafivdQaHujnX2539tYFZtrn-nGRpw/exec" <- could use this?
-    // changed it iin app/.env
+    // changed this in app/.env (add your constant)
     apiUrl:
       import.meta.env.VITE_EMILY_TOURNAMENT_API_URL ||
       "https://script.google.com/macros/s/AKfycby_pE9-KoA_bWjv9xIzNC1DF8jIrMPbQJ3I9P62RafivdQaHujnX2539tYFZtrn-nGRpw/exec",
@@ -87,14 +86,12 @@ export const TOURNAMENT_REGISTRY = [
         displayName: "California",
         target: "wk inc flu hosp",
         horizons: [1, 2, 3],
-        // forecastDate: "2023-11-11",
         forecastDate: "2023-11-18",
       },
       {
         id: "ch-2",
         enabled: true,
         number: 2,
-        // was for Colorado, changed to NE
         title: "Nebraska Influenza Forecast",
         description:
           "Predict Nebraska flu hospitalizations for 1, 2, and 3 weeks ahead",

--- a/app/src/config/tournament.js
+++ b/app/src/config/tournament.js
@@ -59,7 +59,7 @@ export const TOURNAMENT_REGISTRY = [
   {
     id: "emily-tournament",
     enabled: true,
-    path: "/emily_tournament",
+    path: "/emily-tournament",
     navLabel: "EmilyTournament",
     storageKeyPrefix: "emilytesttournament",
     name: "Toy tournament created by Emily",

--- a/app/src/config/tournament.js
+++ b/app/src/config/tournament.js
@@ -57,6 +57,77 @@ const DEFAULT_TOURNAMENT_SETTINGS = {
 
 export const TOURNAMENT_REGISTRY = [
   {
+    id: "emily-tournament",
+    enabled: true,
+    path: "/emily_tournament",
+    navLabel: "EmilyTournament",
+    storageKeyPrefix: "emilytesttournament",
+    name: "Toy tournament created by Emily",
+    description:
+      "Compete in 3 epidemic forecasting challenges and climb the leaderboard",
+    // apiUrl: "https://script.google.com/macros/s/AKfycby_pE9-KoA_bWjv9xIzNC1DF8jIrMPbQJ3I9P62RafivdQaHujnX2539tYFZtrn-nGRpw/exec" <- could use this?
+    // changed it iin app/.env
+    apiUrl:
+      import.meta.env.VITE_EMILY_TOURNAMENT_API_URL ||
+      "https://script.google.com/macros/s/AKfycby_pE9-KoA_bWjv9xIzNC1DF8jIrMPbQJ3I9P62RafivdQaHujnX2539tYFZtrn-nGRpw/exec",
+    sheetId: "1-WMVKajvdkxRpNM7NwYaRYyVK1JdP7jbfV6JooLfguo",
+    challenges: [
+      {
+        id: "ch-1",
+        enabled: true,
+        number: 1,
+        title: "California Influenza Forecast",
+        description:
+          "Predict California flu hospitalizations for 1, 2, and 3 weeks ahead",
+        dataset: "flu",
+        datasetKey: "flusight",
+        dataPath: "flusight",
+        fileSuffix: "flu.json",
+        location: "CA",
+        displayName: "California",
+        target: "wk inc flu hosp",
+        horizons: [1, 2, 3],
+        // forecastDate: "2023-11-11",
+        forecastDate: "2023-11-18",
+      },
+      {
+        id: "ch-2",
+        enabled: true,
+        number: 2,
+        // was for Colorado, changed to NE
+        title: "Nebraska Influenza Forecast",
+        description:
+          "Predict Nebraska flu hospitalizations for 1, 2, and 3 weeks ahead",
+        dataset: "flu",
+        datasetKey: "flusight",
+        dataPath: "flusight",
+        fileSuffix: "flu.json",
+        location: "NE",
+        displayName: "Nebraska",
+        target: "wk inc flu hosp",
+        horizons: [1, 2, 3],
+        forecastDate: "2025-01-18",
+      },
+      {
+        id: "ch-3",
+        enabled: true,
+        number: 3,
+        title: "North Carolina COVID-19 Forecast",
+        description:
+          "Predict North Carolina COVID hospitalizations for 1, 2, and 3 weeks ahead",
+        dataset: "covid",
+        datasetKey: "covid19",
+        dataPath: "covid19forecasthub",
+        fileSuffix: "covid19.json",
+        location: "NC",
+        displayName: "North Carolina",
+        target: "wk inc covid hosp",
+        horizons: [1, 2, 3],
+        forecastDate: "2025-09-13",
+      },
+    ],
+  },
+  {
     id: "epidemics-10",
     enabled: true,
     path: "/epidemics10",
@@ -67,7 +138,6 @@ export const TOURNAMENT_REGISTRY = [
       "Compete in 3 epidemic forecasting challenges and climb the leaderboard",
     apiUrl:
       import.meta.env.VITE_EPIDEMICS10_TOURNAMENT_API_URL ||
-      import.meta.env.VITE_TOURNAMENT_API_URL ||
       "https://script.google.com/macros/s/AKfycbwB7LnE8DSk9S7ACLs20j65iB-9ryCXAiih2FlMwpeWDDE4pLZ1zF3RQilfrm6_byLU7w/exec",
     sheetId: "17J5KWUrVuqmqqBcVJg2A-dfVdrL4LjXTvlztCDpS0g0",
     challenges: [
@@ -174,7 +244,7 @@ export const TOURNAMENT_CONFIG =
   normalizeTournament({
     id: "none",
     enabled: false,
-    path: "/epidemics10",
+    path: "/emily_tournament",
     navLabel: "Tournament",
     name: "Tournament",
     description: "",


### PR DESCRIPTION
testing the new tournament set up infrastructure that Joseph made by adding a tournament `/emily-tournament`. Can replicate these steps to make one for CSTE

to test at programmer meeting tomorrow 