### PR TITLE
fix forecastle resubmission bug

### DIFF
--- a/app/src/components/tournament/TournamentGame.jsx
+++ b/app/src/components/tournament/TournamentGame.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Alert,
   Badge,
@@ -100,6 +100,7 @@ const TournamentGame = ({
   const [loading, setLoading] = useState(true);
 
   const challenge = tournamentConfig.challenges[currentChallengeIndex];
+  const challengeId = challenge?.id;
   const allChallengesCompleted =
     tournamentConfig.numChallenges > 0 &&
     tournamentConfig.challenges.every((ch) => completedChallenges.has(ch.id));
@@ -245,23 +246,35 @@ const TournamentGame = ({
   );
 
   const [forecastEntries, setForecastEntries] = useState(initialInputs);
+  const previousChallengeIdRef = useRef(null);
 
-  // Reset when moving to next challenge
   useEffect(() => {
-    if (!challenge) return;
+    if (!challengeId) return;
 
-    const savedSubmission = savedSubmissions[challenge.id];
-    if (savedSubmission?.forecasts?.length) {
-      setForecastEntries(restoreForecastEntries(savedSubmission.forecasts));
-    } else {
-      setForecastEntries(initialInputs);
+    const savedSubmission = savedSubmissions[challengeId];
+    const hasSavedForecasts = savedSubmission?.forecasts?.length > 0;
+    const challengeChanged = previousChallengeIdRef.current !== challengeId;
+
+    previousChallengeIdRef.current = challengeId;
+
+    if (challengeChanged) {
+      if (hasSavedForecasts) {
+        setForecastEntries(restoreForecastEntries(savedSubmission.forecasts));
+      } else {
+        setForecastEntries(initialInputs);
+      }
+      setSubmissionErrors({});
+      setScores(null);
+      setInputMode("median");
+      setVisibleRankings(0);
+      setError(null);
+      return;
     }
-    setSubmissionErrors({});
-    setScores(null);
-    setInputMode("median");
-    setVisibleRankings(0);
-    setError(null);
-  }, [currentChallengeIndex, initialInputs, challenge, savedSubmissions]);
+
+    if (inputMode !== "scoring" && hasSavedForecasts) {
+      setForecastEntries(restoreForecastEntries(savedSubmission.forecasts));
+    }
+  }, [challengeId, initialInputs, savedSubmissions, inputMode]);
 
   const groundTruthSeries = useMemo(() => {
     if (!challenge || !scenarioData[challenge.number]) return [];

--- a/app/src/utils/tournamentAPI.js
+++ b/app/src/utils/tournamentAPI.js
@@ -5,17 +5,6 @@
 
 import { TOURNAMENT_CONFIG, getChallengeByNumber } from "../config";
 
-const challengeMatchesSubmission = (submission, challenge) => {
-  if (!submission || !challenge) {
-    return false;
-  }
-
-  return (
-    submission.challengeId === challenge.id ||
-    Number(submission.challengeNum) === Number(challenge.number)
-  );
-};
-
 /**
  * Make a GET request to the tournament API
  * @param {string} action - API action
@@ -179,22 +168,6 @@ export const submitForecast = async (
 
   if (!forecasts) {
     throw new Error("Forecast data is required");
-  }
-
-  if (tournamentConfig.features?.allowResubmit === false) {
-    const participantData = await getParticipant(
-      participantId,
-      tournamentConfig,
-    );
-    const alreadySubmitted = participantData.submissions.some((submission) =>
-      challengeMatchesSubmission(submission, challenge),
-    );
-
-    if (alreadySubmitted) {
-      throw new Error(
-        "This challenge has already been submitted. Amendments are disabled for this tournament.",
-      );
-    }
   }
 
   // Convert to array if single forecast object (backward compatibility)


### PR DESCRIPTION
joseph's logic to prevent resubmission created a bug where:

- user submits their first forecastle challenge input
- their input is logged in the spreadsheet 
- our js logic recognizes that they (a participant with an already-used `participant_id`) have already submitted
- it blocks them from submitting anymore (even though they are only on challenge 2/3)

i think this code fixes it? i want to merge to test before creating another tournament for the all hands meeting
