### PR TITLE
switch all of forecastle to rWIS

### DIFF
--- a/app/src/components/forecastle/ForecastleGame.jsx
+++ b/app/src/components/forecastle/ForecastleGame.jsx
@@ -38,10 +38,12 @@ import {
 import { validateForecastSubmission } from "../../utils/forecastleValidation";
 import { FORECASTLE_CONFIG } from "../../config";
 import {
+  addRelativeWISToScore,
+  compareScores,
   extractGroundTruthForHorizons,
-  scoreUserForecast,
-  scoreModels,
   getOfficialModels,
+  scoreModels,
+  scoreUserForecast,
 } from "../../utils/forecastleScoring";
 import {
   saveForecastleGame,
@@ -59,6 +61,30 @@ const addWeeksToDate = (dateString, weeks) => {
   }
   base.setUTCDate(base.getUTCDate() + weeks * 7);
   return base.toISOString().slice(0, 10);
+};
+
+const normalizeScoresForDisplay = (userScore, modelScores, datasetKey) => {
+  const { ensemble: ensembleKey, baseline: baselineKey } =
+    getOfficialModels(datasetKey);
+  const baselineScore =
+    modelScores.find((model) => model.modelName === baselineKey) || null;
+  const baselineWIS = baselineScore?.wis ?? null;
+  const ensembleScore =
+    modelScores.find((model) => model.modelName === ensembleKey) || null;
+
+  const normalizedUserScore = addRelativeWISToScore(userScore, baselineWIS);
+  const normalizedModelScores = modelScores
+    .map((model) => addRelativeWISToScore(model, baselineWIS))
+    .sort(compareScores);
+
+  return {
+    user: normalizedUserScore,
+    models: normalizedModelScores,
+    baselineScore: addRelativeWISToScore(baselineScore, baselineWIS),
+    ensembleScore: addRelativeWISToScore(ensembleScore, baselineWIS),
+    baselineKey,
+    ensembleKey,
+  };
 };
 
 const ForecastleGame = () => {
@@ -158,10 +184,18 @@ const ForecastleGame = () => {
           scenario.horizons,
           groundTruthValues,
         );
+        const normalizedScores = normalizeScoresForDisplay(
+          userScore,
+          modelScores,
+          scenario.dataset.key,
+        );
 
         setScores({
-          user: userScore,
-          models: modelScores,
+          user: normalizedScores.user,
+          models: normalizedScores.models,
+          rawUser: userScore,
+          rawModels: modelScores,
+          baselineWIS: normalizedScores.baselineScore?.wis ?? null,
           groundTruth: groundTruthValues,
           horizonDates,
         });
@@ -282,32 +316,36 @@ const ForecastleGame = () => {
         scenario.horizons,
         groundTruthValues,
       );
+      const normalizedScores = normalizeScoresForDisplay(
+        userScore,
+        modelScores,
+        scenario.dataset.key,
+      );
 
       setScores({
-        user: userScore,
-        models: modelScores,
+        user: normalizedScores.user,
+        models: normalizedScores.models,
+        rawUser: userScore,
+        rawModels: modelScores,
+        baselineWIS: normalizedScores.baselineScore?.wis ?? null,
         groundTruth: groundTruthValues,
         horizonDates,
       });
 
       // Calculate ranking information
-      const { ensemble: ensembleKey, baseline: baselineKey } =
-        getOfficialModels(scenario.dataset.key);
-
-      // Find ensemble and baseline in the model scores
-      const ensembleScore = modelScores.find(
-        (m) => m.modelName === ensembleKey,
-      );
-      const baselineScore = modelScores.find(
-        (m) => m.modelName === baselineKey,
-      );
+      const { ensembleKey, baselineKey, ensembleScore, baselineScore } =
+        normalizedScores;
 
       // Create unified ranking list
       const allRanked = [
-        { name: "user", wis: userScore.wis, isUser: true },
-        ...modelScores.map((m) => ({
+        {
+          name: "user",
+          wis: normalizedScores.user.relativeWis ?? normalizedScores.user.wis,
+          isUser: true,
+        },
+        ...normalizedScores.models.map((m) => ({
           name: m.modelName,
-          wis: m.wis,
+          wis: m.relativeWis ?? m.wis,
           isUser: false,
         })),
       ].sort((a, b) => a.wis - b.wis);
@@ -339,16 +377,19 @@ const ForecastleGame = () => {
           baselineRank,
           // User scores
           userWIS: userScore.wis,
+          userRelativeWIS: normalizedScores.user.relativeWis,
           userDispersion: userScore.dispersion || 0,
           userUnderprediction: userScore.underprediction || 0,
           userOverprediction: userScore.overprediction || 0,
           // Ensemble scores
           ensembleWIS: ensembleScore?.wis || null,
+          ensembleRelativeWIS: ensembleScore?.relativeWis || null,
           ensembleDispersion: ensembleScore?.dispersion || 0,
           ensembleUnderprediction: ensembleScore?.underprediction || 0,
           ensembleOverprediction: ensembleScore?.overprediction || 0,
           // Baseline scores
           baselineWIS: baselineScore?.wis || null,
+          baselineRelativeWIS: baselineScore?.relativeWis || null,
           baselineDispersion: baselineScore?.dispersion || 0,
           baselineUnderprediction: baselineScore?.underprediction || 0,
           baselineOverprediction: baselineScore?.overprediction || 0,
@@ -713,7 +754,8 @@ const ForecastleGame = () => {
                     {saveError}
                   </Alert>
                 )}
-                {scores.user.wis !== null ? (
+                {scores.user.relativeWis !== null ||
+                scores.user.wis !== null ? (
                   <>
                     <Text size="sm" c="dimmed">
                       Based on {scores.user.validCount} of{" "}
@@ -737,12 +779,13 @@ const ForecastleGame = () => {
                               const allEntries = [
                                 {
                                   name: "You",
-                                  wis: scores.user.wis,
+                                  wis:
+                                    scores.user.relativeWis ?? scores.user.wis,
                                   isUser: true,
                                 },
                                 ...scores.models.map((m) => ({
                                   name: m.modelName,
-                                  wis: m.wis,
+                                  wis: m.relativeWis ?? m.wis,
                                   isUser: false,
                                   isHub: m.modelName === ensembleKey,
                                 })),
@@ -958,7 +1001,7 @@ const ForecastleGame = () => {
                                                 : "light"
                                             }
                                           >
-                                            WIS: {entry.wis.toFixed(3)}
+                                            rWIS: {entry.wis.toFixed(3)}
                                           </Badge>
                                         </Group>
                                       </Paper>
@@ -1007,12 +1050,12 @@ const ForecastleGame = () => {
                             const allEntries = [
                               {
                                 name: "You",
-                                wis: scores.user.wis,
+                                wis: scores.user.relativeWis ?? scores.user.wis,
                                 isUser: true,
                               },
                               ...scores.models.map((m) => ({
                                 name: m.modelName,
-                                wis: m.wis,
+                                wis: m.relativeWis ?? m.wis,
                                 isUser: false,
                                 isHub: m.modelName === ensembleKey,
                               })),
@@ -1065,7 +1108,7 @@ const ForecastleGame = () => {
                                 }
                               }
 
-                              return `Forecastle ${scenario.challengeDate}\n${emojis.join("")}\nRank #${userRank}/${totalModels} • WIS: ${scores.user.wis.toFixed(3)}\n${comparisonText}\n${datasetLabel} • ${scenario.location.abbreviation}`;
+                              return `Forecastle ${scenario.challengeDate}\n${emojis.join("")}\nRank #${userRank}/${totalModels} • rWIS: ${(scores.user.relativeWis ?? scores.user.wis).toFixed(3)}\n${comparisonText}\n${datasetLabel} • ${scenario.location.abbreviation}`;
                             };
 
                             const handleCopy = async () => {
@@ -1160,8 +1203,11 @@ const ForecastleGame = () => {
                                         "0 1px 1px rgba(255, 255, 255, 0.6)",
                                     }}
                                   >
-                                    WIS: {scores.user.wis.toFixed(3)} •{" "}
-                                    {scenario.dataset.label} •{" "}
+                                    rWIS:{" "}
+                                    {(
+                                      scores.user.relativeWis ?? scores.user.wis
+                                    ).toFixed(3)}{" "}
+                                    • {scenario.dataset.label} •{" "}
                                     {scenario.location.abbreviation}
                                   </Text>
                                 </Stack>

--- a/app/src/components/forecastle/ForecastleStatsModal.jsx
+++ b/app/src/components/forecastle/ForecastleStatsModal.jsx
@@ -589,9 +589,9 @@ const ForecastleStatsModal = ({ opened, onClose }) => {
                     Performance by Pathogen
                   </Text>
                   <Text size="xs" c="dimmed">
-                    Average WIS scores grouped by disease type. Compare your
-                    performance against the hub ensemble and baseline. Lower
-                    scores indicate better forecasting.
+                    Average relative WIS scores grouped by disease type. Compare
+                    your performance against the hub ensemble and baseline.
+                    Lower scores indicate better forecasting.
                   </Text>
 
                   {/* Summary stats */}
@@ -739,156 +739,183 @@ const ForecastleStatsModal = ({ opened, onClose }) => {
                             <Stack gap={4}>
                               {/* User bar */}
                               <div>
-                                <Text size="xs" fw={500} mb={2}>
-                                  You
-                                </Text>
-                                <Group gap={0} style={{ height: 24 }}>
-                                  {stat.averageUnderprediction !== null &&
-                                    stat.averageUnderprediction > 0 && (
-                                      <div
-                                        style={{
-                                          width: `${(stat.averageUnderprediction / (stat.averageWIS || 1)) * 100}%`,
-                                          height: "100%",
-                                          backgroundColor: "#4c6ef5",
-                                          display: "flex",
-                                          alignItems: "center",
-                                          justifyContent: "center",
-                                        }}
-                                        title={`Underprediction: ${stat.averageUnderprediction.toFixed(3)}`}
-                                      >
-                                        {stat.averageUnderprediction > 5 && (
-                                          <Text size="xs" c="white">
-                                            {stat.averageUnderprediction.toFixed(
-                                              1,
+                                {(() => {
+                                  const userComponentTotal =
+                                    (stat.averageUnderprediction || 0) +
+                                    (stat.averageOverprediction || 0) +
+                                    (stat.averageDispersion || 0);
+                                  return (
+                                    <>
+                                      <Text size="xs" fw={500} mb={2}>
+                                        You
+                                      </Text>
+                                      <Group gap={0} style={{ height: 24 }}>
+                                        {stat.averageUnderprediction !== null &&
+                                          stat.averageUnderprediction > 0 && (
+                                            <div
+                                              style={{
+                                                width: `${(stat.averageUnderprediction / (userComponentTotal || 1)) * 100}%`,
+                                                height: "100%",
+                                                backgroundColor: "#4c6ef5",
+                                                display: "flex",
+                                                alignItems: "center",
+                                                justifyContent: "center",
+                                              }}
+                                              title={`Underprediction: ${stat.averageUnderprediction.toFixed(3)}`}
+                                            >
+                                              {stat.averageUnderprediction >
+                                                5 && (
+                                                <Text size="xs" c="white">
+                                                  {stat.averageUnderprediction.toFixed(
+                                                    1,
+                                                  )}
+                                                </Text>
+                                              )}
+                                            </div>
+                                          )}
+                                        {stat.averageOverprediction !== null &&
+                                          stat.averageOverprediction > 0 && (
+                                            <div
+                                              style={{
+                                                width: `${(stat.averageOverprediction / (userComponentTotal || 1)) * 100}%`,
+                                                height: "100%",
+                                                backgroundColor: "#f03e3e",
+                                                display: "flex",
+                                                alignItems: "center",
+                                                justifyContent: "center",
+                                              }}
+                                              title={`Overprediction: ${stat.averageOverprediction.toFixed(3)}`}
+                                            >
+                                              {stat.averageOverprediction >
+                                                5 && (
+                                                <Text size="xs" c="white">
+                                                  {stat.averageOverprediction.toFixed(
+                                                    1,
+                                                  )}
+                                                </Text>
+                                              )}
+                                            </div>
+                                          )}
+                                        {stat.averageDispersion !== null && (
+                                          <div
+                                            style={{
+                                              width: `${(stat.averageDispersion / (userComponentTotal || 1)) * 100}%`,
+                                              height: "100%",
+                                              backgroundColor: "#adb5bd",
+                                              display: "flex",
+                                              alignItems: "center",
+                                              justifyContent: "center",
+                                            }}
+                                            title={`Dispersion: ${stat.averageDispersion.toFixed(3)}`}
+                                          >
+                                            {stat.averageDispersion > 5 && (
+                                              <Text size="xs" c="white">
+                                                {stat.averageDispersion.toFixed(
+                                                  1,
+                                                )}
+                                              </Text>
                                             )}
-                                          </Text>
+                                          </div>
                                         )}
-                                      </div>
-                                    )}
-                                  {stat.averageOverprediction !== null &&
-                                    stat.averageOverprediction > 0 && (
-                                      <div
-                                        style={{
-                                          width: `${(stat.averageOverprediction / (stat.averageWIS || 1)) * 100}%`,
-                                          height: "100%",
-                                          backgroundColor: "#f03e3e",
-                                          display: "flex",
-                                          alignItems: "center",
-                                          justifyContent: "center",
-                                        }}
-                                        title={`Overprediction: ${stat.averageOverprediction.toFixed(3)}`}
-                                      >
-                                        {stat.averageOverprediction > 5 && (
-                                          <Text size="xs" c="white">
-                                            {stat.averageOverprediction.toFixed(
-                                              1,
-                                            )}
-                                          </Text>
-                                        )}
-                                      </div>
-                                    )}
-                                  {stat.averageDispersion !== null && (
-                                    <div
-                                      style={{
-                                        width: `${(stat.averageDispersion / (stat.averageWIS || 1)) * 100}%`,
-                                        height: "100%",
-                                        backgroundColor: "#adb5bd",
-                                        display: "flex",
-                                        alignItems: "center",
-                                        justifyContent: "center",
-                                      }}
-                                      title={`Dispersion: ${stat.averageDispersion.toFixed(3)}`}
-                                    >
-                                      {stat.averageDispersion > 5 && (
-                                        <Text size="xs" c="white">
-                                          {stat.averageDispersion.toFixed(1)}
-                                        </Text>
-                                      )}
-                                    </div>
-                                  )}
-                                </Group>
+                                      </Group>
+                                    </>
+                                  );
+                                })()}
                               </div>
 
                               {/* Ensemble bar */}
                               {stat.averageEnsembleWIS !== null && (
                                 <div>
-                                  <Text size="xs" fw={500} mb={2}>
-                                    Ensemble
-                                  </Text>
-                                  <Group gap={0} style={{ height: 24 }}>
-                                    {stat.averageEnsembleUnderprediction !==
-                                      null &&
-                                      stat.averageEnsembleUnderprediction >
-                                        0 && (
-                                        <div
-                                          style={{
-                                            width: `${(stat.averageEnsembleUnderprediction / (stat.averageEnsembleWIS || 1)) * 100}%`,
-                                            height: "100%",
-                                            backgroundColor: "#4c6ef5",
-                                            display: "flex",
-                                            alignItems: "center",
-                                            justifyContent: "center",
-                                          }}
-                                          title={`Underprediction: ${stat.averageEnsembleUnderprediction.toFixed(3)}`}
-                                        >
-                                          {stat.averageEnsembleUnderprediction >
-                                            5 && (
-                                            <Text size="xs" c="white">
-                                              {stat.averageEnsembleUnderprediction.toFixed(
-                                                1,
-                                              )}
-                                            </Text>
-                                          )}
-                                        </div>
-                                      )}
-                                    {stat.averageEnsembleOverprediction !==
-                                      null &&
-                                      stat.averageEnsembleOverprediction >
-                                        0 && (
-                                        <div
-                                          style={{
-                                            width: `${(stat.averageEnsembleOverprediction / (stat.averageEnsembleWIS || 1)) * 100}%`,
-                                            height: "100%",
-                                            backgroundColor: "#f03e3e",
-                                            display: "flex",
-                                            alignItems: "center",
-                                            justifyContent: "center",
-                                          }}
-                                          title={`Overprediction: ${stat.averageEnsembleOverprediction.toFixed(3)}`}
-                                        >
-                                          {stat.averageEnsembleOverprediction >
-                                            5 && (
-                                            <Text size="xs" c="white">
-                                              {stat.averageEnsembleOverprediction.toFixed(
-                                                1,
-                                              )}
-                                            </Text>
-                                          )}
-                                        </div>
-                                      )}
-                                    {stat.averageEnsembleDispersion !==
-                                      null && (
-                                      <div
-                                        style={{
-                                          width: `${(stat.averageEnsembleDispersion / (stat.averageEnsembleWIS || 1)) * 100}%`,
-                                          height: "100%",
-                                          backgroundColor: "#adb5bd",
-                                          display: "flex",
-                                          alignItems: "center",
-                                          justifyContent: "center",
-                                        }}
-                                        title={`Dispersion: ${stat.averageEnsembleDispersion.toFixed(3)}`}
-                                      >
-                                        {stat.averageEnsembleDispersion > 5 && (
-                                          <Text size="xs" c="white">
-                                            {stat.averageEnsembleDispersion.toFixed(
-                                              1,
+                                  {(() => {
+                                    const ensembleComponentTotal =
+                                      (stat.averageEnsembleUnderprediction ||
+                                        0) +
+                                      (stat.averageEnsembleOverprediction ||
+                                        0) +
+                                      (stat.averageEnsembleDispersion || 0);
+                                    return (
+                                      <>
+                                        <Text size="xs" fw={500} mb={2}>
+                                          Ensemble
+                                        </Text>
+                                        <Group gap={0} style={{ height: 24 }}>
+                                          {stat.averageEnsembleUnderprediction !==
+                                            null &&
+                                            stat.averageEnsembleUnderprediction >
+                                              0 && (
+                                              <div
+                                                style={{
+                                                  width: `${(stat.averageEnsembleUnderprediction / (ensembleComponentTotal || 1)) * 100}%`,
+                                                  height: "100%",
+                                                  backgroundColor: "#4c6ef5",
+                                                  display: "flex",
+                                                  alignItems: "center",
+                                                  justifyContent: "center",
+                                                }}
+                                                title={`Underprediction: ${stat.averageEnsembleUnderprediction.toFixed(3)}`}
+                                              >
+                                                {stat.averageEnsembleUnderprediction >
+                                                  5 && (
+                                                  <Text size="xs" c="white">
+                                                    {stat.averageEnsembleUnderprediction.toFixed(
+                                                      1,
+                                                    )}
+                                                  </Text>
+                                                )}
+                                              </div>
                                             )}
-                                          </Text>
-                                        )}
-                                      </div>
-                                    )}
-                                  </Group>
+                                          {stat.averageEnsembleOverprediction !==
+                                            null &&
+                                            stat.averageEnsembleOverprediction >
+                                              0 && (
+                                              <div
+                                                style={{
+                                                  width: `${(stat.averageEnsembleOverprediction / (ensembleComponentTotal || 1)) * 100}%`,
+                                                  height: "100%",
+                                                  backgroundColor: "#f03e3e",
+                                                  display: "flex",
+                                                  alignItems: "center",
+                                                  justifyContent: "center",
+                                                }}
+                                                title={`Overprediction: ${stat.averageEnsembleOverprediction.toFixed(3)}`}
+                                              >
+                                                {stat.averageEnsembleOverprediction >
+                                                  5 && (
+                                                  <Text size="xs" c="white">
+                                                    {stat.averageEnsembleOverprediction.toFixed(
+                                                      1,
+                                                    )}
+                                                  </Text>
+                                                )}
+                                              </div>
+                                            )}
+                                          {stat.averageEnsembleDispersion !==
+                                            null && (
+                                            <div
+                                              style={{
+                                                width: `${(stat.averageEnsembleDispersion / (ensembleComponentTotal || 1)) * 100}%`,
+                                                height: "100%",
+                                                backgroundColor: "#adb5bd",
+                                                display: "flex",
+                                                alignItems: "center",
+                                                justifyContent: "center",
+                                              }}
+                                              title={`Dispersion: ${stat.averageEnsembleDispersion.toFixed(3)}`}
+                                            >
+                                              {stat.averageEnsembleDispersion >
+                                                5 && (
+                                                <Text size="xs" c="white">
+                                                  {stat.averageEnsembleDispersion.toFixed(
+                                                    1,
+                                                  )}
+                                                </Text>
+                                              )}
+                                            </div>
+                                          )}
+                                        </Group>
+                                      </>
+                                    );
+                                  })()}
                                 </div>
                               )}
                             </Stack>
@@ -977,7 +1004,7 @@ const ForecastleStatsModal = ({ opened, onClose }) => {
                       <Table.Th>Date</Table.Th>
                       <Table.Th>Dataset</Table.Th>
                       <Table.Th>Location</Table.Th>
-                      <Table.Th>WIS</Table.Th>
+                      <Table.Th>rWIS</Table.Th>
                       <Table.Th>
                         <Tooltip label="Your rank vs all models">
                           <Text size="sm" style={{ cursor: "help" }}>

--- a/app/src/components/tournament/TournamentGame.jsx
+++ b/app/src/components/tournament/TournamentGame.jsx
@@ -35,6 +35,8 @@ import {
   shouldMaskChallengeYear,
 } from "../../config";
 import {
+  addRelativeWISToScore,
+  calculateRelativeWIS,
   scoreUserForecast,
   scoreModels,
   getOfficialModels,
@@ -92,6 +94,8 @@ const restoreForecastEntries = (forecasts) =>
 
 const formatScore = (value) =>
   Number.isFinite(value) ? value.toFixed(1) : "N/A";
+
+const getDisplayScore = (score) => score?.relativeWis ?? score?.wis ?? null;
 
 const getFirstIncompleteChallengeIndex = (challenges, completedChallenges) => {
   const nextIndex = challenges.findIndex(
@@ -480,10 +484,21 @@ const TournamentGame = ({
         challenge.horizons,
         gtData.values,
       );
+      const { baseline: baselineKey } = getOfficialModels(challenge.datasetKey);
+      const baselineScore =
+        modelScores.find((model) => model.modelName === baselineKey) || null;
+      const baselineWIS = baselineScore?.wis ?? null;
+      const normalizedUserScore = addRelativeWISToScore(userScore, baselineWIS);
+      const normalizedModelScores = modelScores.map((model) =>
+        addRelativeWISToScore(model, baselineWIS),
+      );
 
       setScores({
-        user: userScore,
-        models: modelScores,
+        user: normalizedUserScore,
+        models: normalizedModelScores,
+        rawUser: userScore,
+        rawModels: modelScores,
+        baselineWIS,
         groundTruth: gtData.values,
         horizonDates: gtData.dates,
       });
@@ -808,10 +823,15 @@ const ScoreDisplay = ({
 
   // Create unified ranking
   const allRanked = [
-    { name: participantName, wis: scores.user.wis, isUser: true, type: "user" },
+    {
+      name: participantName,
+      wis: getDisplayScore(scores.user),
+      isUser: true,
+      type: "user",
+    },
     ...scores.models.map((m) => ({
       name: m.modelName,
-      wis: m.wis,
+      wis: getDisplayScore(m),
       isUser: false,
       type: "model",
     })),
@@ -837,10 +857,14 @@ const ScoreDisplay = ({
         }));
 
         const pScore = scoreUserForecast(forecastEntries, scores.groundTruth);
-        if (Number.isFinite(pScore.wis)) {
+        const pRelativeWIS = calculateRelativeWIS(
+          pScore.wis,
+          scores.baselineWIS,
+        );
+        if (Number.isFinite(pRelativeWIS)) {
           allRanked.push({
             name: p.name,
-            wis: pScore.wis,
+            wis: pRelativeWIS,
             isUser: false,
             type: "participant",
           });

--- a/app/src/components/tournament/TournamentLeaderboard.jsx
+++ b/app/src/components/tournament/TournamentLeaderboard.jsx
@@ -14,7 +14,12 @@ import {
 import { IconTrophy, IconAlertCircle } from "@tabler/icons-react";
 import { getLeaderboard } from "../../utils/tournamentAPI";
 import { TOURNAMENT_CONFIG } from "../../config";
-import { scoreUserForecast } from "../../utils/forecastleScoring";
+import {
+  calculateRelativeWIS,
+  getOfficialModels,
+  scoreModels,
+  scoreUserForecast,
+} from "../../utils/forecastleScoring";
 
 const addWeeksToDate = (dateString, weeks) => {
   const base = new Date(`${dateString}T00:00:00Z`);
@@ -79,7 +84,24 @@ const TournamentLeaderboard = ({
             return null;
           });
 
-          gtData[challenge.id] = groundTruthForHorizons;
+          const modelScores = scoreModels(
+            locationData.forecasts?.[challenge.forecastDate]?.[
+              challenge.target
+            ] || {},
+            challenge.horizons,
+            groundTruthForHorizons,
+          );
+          const { baseline: baselineKey } = getOfficialModels(
+            challenge.datasetKey,
+          );
+          const baselineScore =
+            modelScores.find((model) => model.modelName === baselineKey) ||
+            null;
+
+          gtData[challenge.id] = {
+            groundTruth: groundTruthForHorizons,
+            baselineWIS: baselineScore?.wis ?? null,
+          };
         } catch (error) {
           console.error(
             `Failed to load ground truth for challenge ${challenge.number}:`,
@@ -103,7 +125,7 @@ const TournamentLeaderboard = ({
         // Calculate WIS for each participant
         const scoredLeaderboard = data.map((participant) => {
           const challengeScores = {};
-          let totalWIS = 0;
+          let totalRelativeWIS = 0;
           let totalDispersion = 0;
           let totalUnderprediction = 0;
           let totalOverprediction = 0;
@@ -125,9 +147,10 @@ const TournamentLeaderboard = ({
               participant.submissions,
               challenge,
             );
-            const groundTruth = groundTruthData[challenge.id];
+            const challengeScoreData = groundTruthData[challenge.id];
 
-            if (!groundTruth || !forecasts || forecasts.length === 0) return;
+            if (!challengeScoreData || !forecasts || forecasts.length === 0)
+              return;
 
             // Convert forecasts to the format expected by scoreUserForecast
             const forecastEntries = forecasts.map((f) => ({
@@ -140,15 +163,22 @@ const TournamentLeaderboard = ({
             }));
 
             // Calculate WIS with components
-            const scoreResult = scoreUserForecast(forecastEntries, groundTruth);
-            if (scoreResult.wis !== null) {
+            const scoreResult = scoreUserForecast(
+              forecastEntries,
+              challengeScoreData.groundTruth,
+            );
+            const relativeWis = calculateRelativeWIS(
+              scoreResult.wis,
+              challengeScoreData.baselineWIS,
+            );
+            if (Number.isFinite(relativeWis)) {
               challengeScores[challenge.id] = {
-                wis: scoreResult.wis,
+                wis: relativeWis,
                 dispersion: scoreResult.dispersion,
                 underprediction: scoreResult.underprediction,
                 overprediction: scoreResult.overprediction,
               };
-              totalWIS += scoreResult.wis;
+              totalRelativeWIS += relativeWis;
               totalDispersion += scoreResult.dispersion;
               totalUnderprediction += scoreResult.underprediction;
               totalOverprediction += scoreResult.overprediction;
@@ -157,7 +187,7 @@ const TournamentLeaderboard = ({
           });
 
           const avgWIS =
-            validChallenges > 0 ? totalWIS / validChallenges : null;
+            validChallenges > 0 ? totalRelativeWIS / validChallenges : null;
           const avgDispersion =
             validChallenges > 0 ? totalDispersion / validChallenges : null;
           const avgUnderprediction =
@@ -167,7 +197,7 @@ const TournamentLeaderboard = ({
 
           return {
             ...participant,
-            totalWIS: validChallenges > 0 ? totalWIS : null,
+            totalWIS: validChallenges > 0 ? totalRelativeWIS : null,
             avgWIS,
             avgDispersion,
             avgUnderprediction,
@@ -268,8 +298,8 @@ const TournamentLeaderboard = ({
       </Title>
 
       <Text size="sm" color="dimmed">
-        Ranked by average WIS (lower is better). Completed participants ranked
-        first.
+        Ranked by average relative WIS (lower is better). Completed participants
+        ranked first.
       </Text>
 
       <Stack spacing="sm">
@@ -278,8 +308,8 @@ const TournamentLeaderboard = ({
             <tr>
               <th style={{ width: 60 }}>Rank</th>
               <th>Participant</th>
-              <th style={{ textAlign: "right", width: 90 }}>Avg WIS</th>
-              <th style={{ textAlign: "right", width: 90 }}>Total WIS</th>
+              <th style={{ textAlign: "right", width: 90 }}>Avg rWIS</th>
+              <th style={{ textAlign: "right", width: 90 }}>Total rWIS</th>
               {tournamentConfig.challenges.map((ch) => (
                 <th key={ch.number} style={{ textAlign: "center", width: 80 }}>
                   Ch {ch.number}

--- a/app/src/components/tournament/TournamentLeaderboard.jsx
+++ b/app/src/components/tournament/TournamentLeaderboard.jsx
@@ -309,7 +309,6 @@ const TournamentLeaderboard = ({
               <th style={{ width: 60 }}>Rank</th>
               <th>Participant</th>
               <th style={{ textAlign: "right", width: 90 }}>Avg rWIS</th>
-              <th style={{ textAlign: "right", width: 90 }}>Total rWIS</th>
               {tournamentConfig.challenges.map((ch) => (
                 <th key={ch.number} style={{ textAlign: "center", width: 80 }}>
                   Ch {ch.number}
@@ -418,13 +417,6 @@ const TournamentLeaderboard = ({
                     <td style={{ textAlign: "right" }}>
                       <Text size="sm" weight={isUser ? 700 : 400}>
                         {entry.avgWIS !== null ? entry.avgWIS.toFixed(1) : "—"}
-                      </Text>
-                    </td>
-                    <td style={{ textAlign: "right" }}>
-                      <Text size="sm">
-                        {entry.totalWIS !== null
-                          ? entry.totalWIS.toFixed(1)
-                          : "—"}
                       </Text>
                     </td>
                     {tournamentConfig.challenges.map((ch) => (

--- a/app/src/hooks/useRespilensStats.js
+++ b/app/src/hooks/useRespilensStats.js
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { getForecastleGames } from "../utils/respilensStorage";
-import { calculateWIS } from "../utils/forecastleScoring";
+import { calculateRelativeWIS, calculateWIS } from "../utils/forecastleScoring";
 
 /**
  * Calculate interval coverage for a single game
@@ -80,6 +80,9 @@ function computeGameStats(game) {
   });
 
   const wis = validCount > 0 ? sumWIS / validCount : null;
+  const relativeWis =
+    game.userRelativeWIS ??
+    calculateRelativeWIS(game.userWIS ?? wis, game.baselineWIS ?? null);
   const dispersion = validCount > 0 ? sumDispersion / validCount : null;
   const underprediction =
     validCount > 0 ? sumUnderprediction / validCount : null;
@@ -99,10 +102,12 @@ function computeGameStats(game) {
     location: game.location,
     target: game.target,
     // User WIS (computed or from storage)
-    wis: game.userWIS || wis,
-    dispersion: game.userDispersion || dispersion,
-    underprediction: game.userUnderprediction || underprediction,
-    overprediction: game.userOverprediction || overprediction,
+    wis: relativeWis,
+    rawWIS: game.userWIS ?? wis,
+    relativeWIS: relativeWis,
+    dispersion: game.userDispersion ?? dispersion,
+    underprediction: game.userUnderprediction ?? underprediction,
+    overprediction: game.userOverprediction ?? overprediction,
     coverage95: coverage.coverage95,
     coverage50: coverage.coverage50,
     validHorizons: coverage.validHorizons,
@@ -113,15 +118,21 @@ function computeGameStats(game) {
     ensembleRank: game.ensembleRank || null,
     baselineRank: game.baselineRank || null,
     // Ensemble scores
-    ensembleWIS: game.ensembleWIS || null,
-    ensembleDispersion: game.ensembleDispersion || null,
-    ensembleUnderprediction: game.ensembleUnderprediction || null,
-    ensembleOverprediction: game.ensembleOverprediction || null,
+    ensembleWIS:
+      game.ensembleRelativeWIS ??
+      calculateRelativeWIS(game.ensembleWIS ?? null, game.baselineWIS ?? null),
+    ensembleRawWIS: game.ensembleWIS ?? null,
+    ensembleDispersion: game.ensembleDispersion ?? null,
+    ensembleUnderprediction: game.ensembleUnderprediction ?? null,
+    ensembleOverprediction: game.ensembleOverprediction ?? null,
     // Baseline scores
-    baselineWIS: game.baselineWIS || null,
-    baselineDispersion: game.baselineDispersion || null,
-    baselineUnderprediction: game.baselineUnderprediction || null,
-    baselineOverprediction: game.baselineOverprediction || null,
+    baselineWIS:
+      game.baselineRelativeWIS ??
+      calculateRelativeWIS(game.baselineWIS ?? null, game.baselineWIS ?? null),
+    baselineRawWIS: game.baselineWIS ?? null,
+    baselineDispersion: game.baselineDispersion ?? null,
+    baselineUnderprediction: game.baselineUnderprediction ?? null,
+    baselineOverprediction: game.baselineOverprediction ?? null,
     // Raw data needed for per-pathogen coverage calculation
     userForecasts: game.userForecasts,
     groundTruth: game.groundTruth,
@@ -213,6 +224,7 @@ export function useRespilensStats(refreshTrigger) {
         averageWIS: null,
         bestWIS: null,
         worstWIS: null,
+        averageRawWIS: null,
         averageDispersion: null,
         averageUnderprediction: null,
         averageOverprediction: null,
@@ -236,6 +248,9 @@ export function useRespilensStats(refreshTrigger) {
     const totalWIS = validGames.reduce((sum, g) => sum + g.wis, 0);
     const averageWIS =
       validGames.length > 0 ? totalWIS / validGames.length : null;
+    const totalRawWIS = validGames.reduce((sum, g) => sum + (g.rawWIS || 0), 0);
+    const averageRawWIS =
+      validGames.length > 0 ? totalRawWIS / validGames.length : null;
     const bestWIS =
       validGames.length > 0 ? Math.min(...validGames.map((g) => g.wis)) : null;
     const worstWIS =
@@ -315,6 +330,7 @@ export function useRespilensStats(refreshTrigger) {
       averageWIS,
       bestWIS,
       worstWIS,
+      averageRawWIS,
       averageDispersion,
       averageUnderprediction,
       averageOverprediction,

--- a/app/src/lib/forecast-components/scoring.js
+++ b/app/src/lib/forecast-components/scoring.js
@@ -3,9 +3,13 @@
  * WIS is re-exported from the canonical Forecastle scoring utility.
  */
 
-import { calculateWIS } from "../../utils/forecastleScoring.js";
+import {
+  calculateRelativeWIS,
+  calculateWIS,
+} from "../../utils/forecastleScoring.js";
 
 export { calculateWIS };
+export { calculateRelativeWIS };
 
 /**
  * Validate forecast intervals
@@ -88,4 +92,52 @@ export const calculateAverageWIS = (forecasts, observations) => {
   if (wisScores.length === 0) return null;
 
   return wisScores.reduce((sum, score) => sum + score, 0) / wisScores.length;
+};
+
+/**
+ * Calculate average relative WIS across multiple forecasts.
+ * @param {Array} forecasts - Array of forecast objects
+ * @param {Array} observations - Array of observed values
+ * @param {Array} baselineScores - Array of raw baseline WIS values
+ * @returns {number|null} Average relative WIS
+ */
+export const calculateAverageRelativeWIS = (
+  forecasts,
+  observations,
+  baselineScores,
+) => {
+  if (
+    !forecasts ||
+    !observations ||
+    !baselineScores ||
+    forecasts.length !== observations.length ||
+    forecasts.length !== baselineScores.length
+  ) {
+    return null;
+  }
+
+  const relativeScores = forecasts
+    .map((forecast, idx) => {
+      const obs = observations[idx];
+      if (!Number.isFinite(obs)) return null;
+
+      const result = calculateWIS(
+        obs,
+        forecast.median,
+        forecast.q25,
+        forecast.q75,
+        forecast.q025,
+        forecast.q975,
+      );
+
+      return calculateRelativeWIS(result?.wis ?? null, baselineScores[idx]);
+    })
+    .filter((score) => Number.isFinite(score));
+
+  if (relativeScores.length === 0) return null;
+
+  return (
+    relativeScores.reduce((sum, score) => sum + score, 0) /
+    relativeScores.length
+  );
 };

--- a/app/src/utils/forecastleScoring.js
+++ b/app/src/utils/forecastleScoring.js
@@ -232,6 +232,52 @@ export const scoreUserForecast = (userForecasts, groundTruthValues) => {
 };
 
 /**
+ * Calculate relative WIS using an official baseline model score.
+ * Lower is better; the baseline model has relative WIS 1.0.
+ * @param {number} wis - Raw WIS for the forecast being scored
+ * @param {number} baselineWIS - Raw WIS for the official baseline model
+ * @returns {number|null} Relative WIS or null if unavailable
+ */
+export const calculateRelativeWIS = (wis, baselineWIS) => {
+  if (!Number.isFinite(wis) || !Number.isFinite(baselineWIS)) {
+    return null;
+  }
+
+  if (baselineWIS === 0) {
+    return wis === 0 ? 1 : null;
+  }
+
+  return wis / baselineWIS;
+};
+
+/**
+ * Attach relative WIS to an existing score object.
+ * @param {Object|null} score - Score object containing a raw `wis` field
+ * @param {number} baselineWIS - Raw WIS for the official baseline model
+ * @returns {Object|null} Score object with `relativeWis`
+ */
+export const addRelativeWISToScore = (score, baselineWIS) => {
+  if (!score) return score;
+
+  return {
+    ...score,
+    relativeWis: calculateRelativeWIS(score.wis, baselineWIS),
+  };
+};
+
+/**
+ * Compare score objects using relative WIS when available, otherwise raw WIS.
+ * @param {Object} a - Score-like object
+ * @param {Object} b - Score-like object
+ * @returns {number} Sort comparator result
+ */
+export const compareScores = (a, b) => {
+  const aValue = a?.relativeWis ?? a?.wis ?? Infinity;
+  const bValue = b?.relativeWis ?? b?.wis ?? Infinity;
+  return aValue - bValue;
+};
+
+/**
  * Get official ensemble and baseline model names for a dataset
  * @param {string} datasetKey - Dataset key (e.g., 'flusight', 'rsv', 'covid19')
  * @returns {Object} Object with ensembleKey and baselineKey

--- a/app/src/utils/respilensStorage.js
+++ b/app/src/utils/respilensStorage.js
@@ -129,11 +129,13 @@ export function saveForecastleGame(gameData) {
       baselineRank: gameData.baselineRank,
       // User scores (rounded to 3 decimal places)
       userWIS: roundToDecimals(gameData.userWIS, 3),
+      userRelativeWIS: roundToDecimals(gameData.userRelativeWIS, 3),
       userDispersion: roundToDecimals(gameData.userDispersion, 3),
       userUnderprediction: roundToDecimals(gameData.userUnderprediction, 3),
       userOverprediction: roundToDecimals(gameData.userOverprediction, 3),
       // Ensemble scores (rounded to 3 decimal places)
       ensembleWIS: roundToDecimals(gameData.ensembleWIS, 3),
+      ensembleRelativeWIS: roundToDecimals(gameData.ensembleRelativeWIS, 3),
       ensembleDispersion: roundToDecimals(gameData.ensembleDispersion, 3),
       ensembleUnderprediction: roundToDecimals(
         gameData.ensembleUnderprediction,
@@ -145,6 +147,7 @@ export function saveForecastleGame(gameData) {
       ),
       // Baseline scores (rounded to 3 decimal places)
       baselineWIS: roundToDecimals(gameData.baselineWIS, 3),
+      baselineRelativeWIS: roundToDecimals(gameData.baselineRelativeWIS, 3),
       baselineDispersion: roundToDecimals(gameData.baselineDispersion, 3),
       baselineUnderprediction: roundToDecimals(
         gameData.baselineUnderprediction,


### PR DESCRIPTION
Instead of average WIS, we are now going to use average relative WIS. rWIS is less sensitive to the scale of the data, which makes it better given that we are comparing forecasts across different pathogens, weeks, locations. This was brought up in the ACCIDDA all-hands meeting, so I looked into it and wanted to implement it quickly before CSTE, but it is pretty inconsequential and we can revert to WIS after if we want. 