### PR TITLE
Create "compare with submitting models" functionality to MyRespiLens

### DIFF
--- a/app/src/components/FluPeak.jsx
+++ b/app/src/components/FluPeak.jsx
@@ -1,12 +1,13 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { Stack, useMantineColorScheme } from "@mantine/core";
 import Plot from "react-plotly.js";
 import ModelSelector from "./ModelSelector";
-import { MODEL_COLORS } from "../config/datasets";
+import { getModelColor } from "../config/datasets";
 import { CHART_CONSTANTS } from "../constants/chart";
 import { getDataPath } from "../utils/paths";
 import { buildSqrtTicks, getYRangeFromTraces } from "../utils/scaleUtils";
 import { buildPlotDownloadName } from "../utils/plotDownloadName";
+import { extendStableModelOrder } from "../utils/modelColorUtils";
 
 // helper to convert Hex to RGBA for opacity control
 const hexToRgba = (hex, alpha) => {
@@ -48,6 +49,15 @@ const FluPeak = ({
   const showMedian = intervalVisibility?.median ?? true;
   const show50 = intervalVisibility?.ci50 ?? true;
   const show95 = intervalVisibility?.ci95 ?? true;
+  const stableModelOrderRef = useRef([]);
+  const stableModelOrder = useMemo(() => {
+    const nextOrder = extendStableModelOrder(
+      stableModelOrderRef.current,
+      selectedModels,
+    );
+    stableModelOrderRef.current = nextOrder;
+    return nextOrder;
+  }, [selectedModels]);
 
   const getNormalizedDate = (dateStr) => {
     const d = new Date(dateStr);
@@ -202,8 +212,7 @@ const FluPeak = ({
         const pointColors = [];
 
         // Base color for this model (Solid, used for Legend)
-        const baseColorHex =
-          MODEL_COLORS[selectedModels.indexOf(model) % MODEL_COLORS.length];
+        const baseColorHex = getModelColor(model, stableModelOrder);
 
         datesToCheck.forEach((refDate, index) => {
           const dateData = peaks[refDate];
@@ -489,6 +498,7 @@ const FluPeak = ({
     show50,
     show95,
     chartScale,
+    stableModelOrder,
   ]);
 
   const sqrtTicks = useMemo(() => {
@@ -641,10 +651,6 @@ const FluPeak = ({
           selectedModels={selectedModels}
           setSelectedModels={setSelectedModels}
           activeModels={activePeakModels}
-          getModelColor={(model, currentSelected) => {
-            const index = currentSelected.indexOf(model);
-            return MODEL_COLORS[index % MODEL_COLORS.length];
-          }}
         />
       </Stack>
     </Stack>

--- a/app/src/components/ForecastPlotView.jsx
+++ b/app/src/components/ForecastPlotView.jsx
@@ -4,7 +4,6 @@ import Plot from "react-plotly.js";
 import Plotly from "plotly.js/dist/plotly";
 import ModelSelector from "./ModelSelector";
 import TitleRow from "./TitleRow";
-import { MODEL_COLORS } from "../config/datasets";
 import { CHART_CONSTANTS } from "../constants/chart";
 import { targetDisplayNameMap, targetYAxisLabelMap } from "../utils/mapUtils";
 import useQuantileForecastTraces from "../hooks/useQuantileForecastTraces";
@@ -433,10 +432,6 @@ const ForecastPlotView = ({
           selectedModels={selectedModels}
           setSelectedModels={setSelectedModels}
           activeModels={activeModels}
-          getModelColor={(model, currentSelected) => {
-            const index = currentSelected.indexOf(model);
-            return MODEL_COLORS[index % MODEL_COLORS.length];
-          }}
         />
       </Stack>
     </Stack>

--- a/app/src/components/ModelSelector.jsx
+++ b/app/src/components/ModelSelector.jsx
@@ -29,6 +29,7 @@ const ModelSelector = ({
   activeModels = null,
   allowMultiple = true,
   disabled = false,
+  modelColorFn = null,
 }) => {
   const [showAllAvailable, setShowAllAvailable] = useState(false);
   const [search, setSearch] = useState("");
@@ -50,7 +51,10 @@ const ModelSelector = ({
   };
 
   const getModelColorByIndex = (model) => {
-    // Only color selected models to avoid mismatched palette hints
+    if (modelColorFn) {
+      return modelColorFn(model, selectedModels);
+    }
+
     const index = selectedModels.indexOf(model);
     return index >= 0 ? MODEL_COLORS[index % MODEL_COLORS.length] : undefined;
   };

--- a/app/src/components/ModelSelector.jsx
+++ b/app/src/components/ModelSelector.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import {
   Stack,
   Group,
@@ -20,7 +20,8 @@ import {
   IconEye,
   IconEyeOff,
 } from "@tabler/icons-react";
-import { MODEL_COLORS } from "../config/datasets";
+import { getModelColor } from "../config/datasets";
+import { extendStableModelOrder } from "../utils/modelColorUtils";
 
 const ModelSelector = ({
   models = [],
@@ -30,13 +31,23 @@ const ModelSelector = ({
   allowMultiple = true,
   disabled = false,
   modelColorFn = null,
+  getModelColor: legacyGetModelColor = null,
 }) => {
   const [showAllAvailable, setShowAllAvailable] = useState(false);
   const [search, setSearch] = useState("");
+  const stableModelOrderRef = useRef([]);
   const combobox = useCombobox({
     onDropdownClose: () => combobox.resetSelectedOption(),
     onDropdownOpen: () => combobox.updateSelectedOptionIndex("active", 0),
   });
+  const stableModelOrder = useMemo(() => {
+    const nextOrder = extendStableModelOrder(
+      stableModelOrderRef.current,
+      selectedModels,
+    );
+    stableModelOrderRef.current = nextOrder;
+    return nextOrder;
+  }, [selectedModels]);
 
   const handleSelectAll = () => {
     // Only select models that are currently active
@@ -51,12 +62,12 @@ const ModelSelector = ({
   };
 
   const getModelColorByIndex = (model) => {
-    if (modelColorFn) {
-      return modelColorFn(model, selectedModels);
+    const resolvedColorFn = modelColorFn || legacyGetModelColor;
+    if (resolvedColorFn) {
+      return resolvedColorFn(model, selectedModels, stableModelOrder);
     }
 
-    const index = selectedModels.indexOf(model);
-    return index >= 0 ? MODEL_COLORS[index % MODEL_COLORS.length] : undefined;
+    return getModelColor(model, stableModelOrder) ?? undefined;
   };
 
   const modelsToShow = showAllAvailable ? models : selectedModels;

--- a/app/src/components/layout/MainNavigation.jsx
+++ b/app/src/components/layout/MainNavigation.jsx
@@ -41,7 +41,7 @@ const MainNavigation = () => {
     },
     {
       href: "/myplots",
-      label: "My Plots (α)",
+      label: "My Plots",
       icon: IconChartScatter,
       active: isActive("/myplots"),
     },

--- a/app/src/components/myplots/MiniPlot.jsx
+++ b/app/src/components/myplots/MiniPlot.jsx
@@ -12,7 +12,7 @@ import {
 } from "@mantine/core";
 import Plot from "react-plotly.js";
 import useQuantileForecastTraces from "../../hooks/useQuantileForecastTraces";
-import { MODEL_COLORS } from "../../config/datasets";
+import { getModelColor } from "../../config/datasets";
 import { nhsnSlugToNameMap, targetDisplayNameMap } from "../../utils/mapUtils";
 import { buildSqrtTicks, getYRangeFromTraces } from "../../utils/scaleUtils";
 
@@ -75,6 +75,7 @@ const MiniPlot = ({ plot, onMetadataLoad, plotHeight = 210 }) => {
     forecasts: isSeriesView || isFluPeak ? null : data?.forecasts,
     selectedDates: plot.settings.dates || [],
     selectedModels: plot.settings.models || [],
+    modelOrder: plot.settings.models || [],
     target: plot.settings.target,
     showMedian: plot.settings.intervals?.includes("median") ?? true,
     show50: plot.settings.intervals?.includes("ci50") ?? true,
@@ -91,7 +92,7 @@ const MiniPlot = ({ plot, onMetadataLoad, plotHeight = 210 }) => {
     const applySqrt = plot.settings.scale === "sqrt";
 
     return (plot.settings.columns || [])
-      .map((slug, index) => {
+      .map((slug) => {
         const longformName = nhsnSlugToNameMap[slug] || slug;
         const rawY = data.series[longformName] || [];
         const yValues = applySqrt
@@ -107,7 +108,7 @@ const MiniPlot = ({ plot, onMetadataLoad, plotHeight = 210 }) => {
           type: "scatter",
           mode: "lines",
           line: {
-            color: MODEL_COLORS[index % MODEL_COLORS.length],
+            color: getModelColor(slug, plot.settings.columns || []),
             width: 2,
           },
         };
@@ -122,7 +123,7 @@ const MiniPlot = ({ plot, onMetadataLoad, plotHeight = 210 }) => {
     const applySqrt = plot.settings.scale === "sqrt";
 
     return (plot.settings.columns || [])
-      .map((column, index) => {
+      .map((column) => {
         const rawY = data.series[column] || [];
         const yValues = applySqrt
           ? rawY.map((value) =>
@@ -137,7 +138,7 @@ const MiniPlot = ({ plot, onMetadataLoad, plotHeight = 210 }) => {
           type: "scatter",
           mode: "lines+markers",
           line: {
-            color: MODEL_COLORS[index % MODEL_COLORS.length],
+            color: getModelColor(column, plot.settings.columns || []),
             width: 2,
           },
           marker: { size: 4 },
@@ -196,8 +197,8 @@ const MiniPlot = ({ plot, onMetadataLoad, plotHeight = 210 }) => {
       }
     }
 
-    selectedModels.forEach((model, modelIndex) => {
-      const baseColor = MODEL_COLORS[modelIndex % MODEL_COLORS.length];
+    selectedModels.forEach((model) => {
+      const baseColor = getModelColor(model, plot.settings.models || []);
 
       selectedDates.forEach((referenceDate, dateIndex) => {
         const dateData = peaks?.[referenceDate];

--- a/app/src/components/myplots/MyPlots.jsx
+++ b/app/src/components/myplots/MyPlots.jsx
@@ -212,16 +212,7 @@ const MyPlots = () => {
                   <Text size="sm" c="dimmed">
                     You haven't added any visualizations to <b>My Plots</b> yet.
                     Click the "Add to My Plots" button on any plot to see it
-                    here with any editorializations you choose. This feature is
-                    in its alpha release; if you encounter bugs or have
-                    suggestions, please report them{" "}
-                    <a
-                      href="https://github.com/ACCIDDA/RespiLens/issues/new?title=%E2%80%BC%EF%B8%8FMy%20Plots:%20user%20bug%20or%20suggestion%20%E2%80%BC%EF%B8%8F"
-                      rel="noopener"
-                      target="_blank"
-                    >
-                      here.
-                    </a>
+                    here with any editorializations you choose.
                   </Text>
                 </div>
 
@@ -245,18 +236,6 @@ const MyPlots = () => {
                   <Title order={2}>My Plots</Title>
                   <Text size="sm" c="dimmed">
                     Your personalized library of saved visualizations.
-                  </Text>
-                  <Text size="sm" c="dimmed">
-                    This feature is in its alpha release, and is still under
-                    develoment. If you encounter a bug or have a suggestion,
-                    please{" "}
-                    <a
-                      href="https://github.com/ACCIDDA/RespiLens/issues/new?title=%E2%80%BC%EF%B8%8FMy%20Plots:%20user%20bug%20or%20suggestion%20%E2%80%BC%EF%B8%8F"
-                      rel="noopener"
-                      target="_blank"
-                    >
-                      let us know.
-                    </a>
                   </Text>
                 </div>
                 <Badge variant="filled" size="lg" color="blue">

--- a/app/src/components/myrespi/MyRespiLensDashboard.jsx
+++ b/app/src/components/myrespi/MyRespiLensDashboard.jsx
@@ -39,6 +39,7 @@ import Seo from "../Seo";
 import useQuantileForecastTraces from "../../hooks/useQuantileForecastTraces";
 import { MODEL_COLORS } from "../../config/datasets";
 import { CHART_CONSTANTS } from "../../constants/chart";
+import { extendStableModelOrder } from "../../utils/modelColorUtils";
 import { buildSqrtTicks } from "../../utils/scaleUtils";
 
 const HUB_OPTIONS = [
@@ -1092,35 +1093,6 @@ const buildComparisonHoverText = ({
   return rows.join("");
 };
 
-const lightenHexColor = (hexColor, factor = 0.4) => {
-  if (!/^#[0-9a-f]{6}$/i.test(hexColor)) {
-    return hexColor;
-  }
-
-  const red = Number.parseInt(hexColor.slice(1, 3), 16);
-  const green = Number.parseInt(hexColor.slice(3, 5), 16);
-  const blue = Number.parseInt(hexColor.slice(5, 7), 16);
-
-  const lightenChannel = (channel) =>
-    Math.round(channel + (255 - channel) * factor)
-      .toString(16)
-      .padStart(2, "0");
-
-  return `#${lightenChannel(red)}${lightenChannel(green)}${lightenChannel(blue)}`;
-};
-
-const getSubmittedModelColor = (model, selectedModels) => {
-  const index = selectedModels.indexOf(model);
-  if (index < 0) {
-    return null;
-  }
-
-  const offsetIndex =
-    (index + Math.ceil(MODEL_COLORS.length / 2)) % MODEL_COLORS.length;
-  const baseColor = MODEL_COLORS[offsetIndex];
-  return lightenHexColor(baseColor, 0.2);
-};
-
 const filterComparisonLocationData = (
   comparisonLocationData,
   userLocationData,
@@ -1226,6 +1198,7 @@ const MyRespiVisualizationPanel = ({
   const plotRef = useRef(null);
   const isResettingRef = useRef(false);
   const comparisonCacheRef = useRef(new Map());
+  const userModelOrderRef = useRef([]);
 
   const locationOptions = useMemo(
     () => buildLocationOptions(projectionOutputs),
@@ -1454,6 +1427,48 @@ const MyRespiVisualizationPanel = ({
     });
   }, [submittedModels]);
 
+  const stableUserModelOrder = useMemo(() => {
+    const nextOrder = extendStableModelOrder(
+      userModelOrderRef.current,
+      selectedModels,
+    );
+    userModelOrderRef.current = nextOrder;
+    return nextOrder;
+  }, [selectedModels]);
+
+  const submittedModelPalette = useMemo(() => {
+    const reservedColors = new Set(
+      selectedModels
+        .map((model) => {
+          const index = stableUserModelOrder.indexOf(model);
+          if (index < 0) {
+            return null;
+          }
+
+          return MODEL_COLORS[index % MODEL_COLORS.length];
+        })
+        .filter(Boolean),
+    );
+
+    const availableColors = MODEL_COLORS.filter(
+      (color) => !reservedColors.has(color),
+    );
+
+    return availableColors.length ? availableColors : MODEL_COLORS;
+  }, [selectedModels, stableUserModelOrder]);
+
+  const submittedModelColorFn = useCallback(
+    (model, submittedSelection, submittedModelOrder = submittedSelection) => {
+      const index = submittedModelOrder.indexOf(model);
+      if (index < 0) {
+        return null;
+      }
+
+      return submittedModelPalette[index % submittedModelPalette.length];
+    },
+    [submittedModelPalette],
+  );
+
   const availableDates = useMemo(
     () => getAllForecastDates(projectionOutputs),
     [projectionOutputs],
@@ -1541,7 +1556,7 @@ const MyRespiVisualizationPanel = ({
     showMedian: true,
     show50: true,
     show95: true,
-    modelColorFn: getSubmittedModelColor,
+    modelColorFn: submittedModelColorFn,
     modelHoverBuilder: buildComparisonHoverText,
     transformY: sqrtTransform,
   });
@@ -1820,49 +1835,6 @@ const MyRespiVisualizationPanel = ({
           </Stack>
         </Paper>
 
-        <Paper withBorder radius="md" p="sm">
-          <Stack gap="xs">
-            <Group justify="space-between" align="center">
-              <Text fw={600} size="sm">
-                Compare with submitting models
-              </Text>
-              <Switch
-                checked={compareWithSubmittingModels}
-                onChange={(event) =>
-                  setCompareWithSubmittingModels(event.currentTarget.checked)
-                }
-                disabled={!comparisonEligibility?.isEligible}
-                size="sm"
-              />
-            </Group>
-            <Text size="sm" c="dimmed">
-              {comparisonEligibility?.isEligible
-                ? "Load submitted model forecasts for the same past issue dates and location."
-                : comparisonEligibility?.reason}
-            </Text>
-            {compareWithSubmittingModels &&
-              comparisonDataState.status === "loading" && (
-                <Group gap="xs">
-                  <Loader size="sm" color="blue" />
-                  <Text size="sm" c="dimmed">
-                    Loading submitted model data for this location...
-                  </Text>
-                </Group>
-              )}
-            {compareWithSubmittingModels &&
-              comparisonDataState.status === "error" && (
-                <Alert
-                  color="red"
-                  variant="light"
-                  radius="md"
-                  icon={<IconAlertCircle size={16} />}
-                >
-                  {comparisonDataState.error}
-                </Alert>
-              )}
-          </Stack>
-        </Paper>
-
         <DateSelector
           availableDates={availableDates}
           selectedDates={selectedDates}
@@ -1896,18 +1868,53 @@ const MyRespiVisualizationPanel = ({
           activeModels={activeModels}
         />
 
+        <Paper withBorder radius="md" p="sm">
+          <Stack gap="xs">
+            <Group justify="space-between" align="center">
+              <Text fw={600} size="sm">
+                Compare with submitting models
+              </Text>
+              <Switch
+                checked={compareWithSubmittingModels}
+                onChange={(event) =>
+                  setCompareWithSubmittingModels(event.currentTarget.checked)
+                }
+                disabled={!comparisonEligibility?.isEligible}
+                size="sm"
+              />
+            </Group>
+            {compareWithSubmittingModels &&
+              comparisonDataState.status === "loading" && (
+                <Group gap="xs">
+                  <Loader size="sm" color="blue" />
+                  <Text size="sm" c="dimmed">
+                    Loading submitted model data for this location...
+                  </Text>
+                </Group>
+              )}
+            {compareWithSubmittingModels &&
+              comparisonDataState.status === "error" && (
+                <Alert
+                  color="red"
+                  variant="light"
+                  radius="md"
+                  icon={<IconAlertCircle size={16} />}
+                >
+                  {comparisonDataState.error}
+                </Alert>
+              )}
+          </Stack>
+        </Paper>
+
         {compareWithSubmittingModels &&
           comparisonDataState.status === "success" && (
             <Stack gap="xs">
-              <Text fw={600} size="sm">
-                Submitted models
-              </Text>
               <ModelSelector
                 models={submittedModels}
                 selectedModels={selectedSubmittedModels}
                 setSelectedModels={setSelectedSubmittedModels}
                 activeModels={activeSubmittedModels}
-                modelColorFn={getSubmittedModelColor}
+                modelColorFn={submittedModelColorFn}
               />
             </Stack>
           )}

--- a/app/src/components/myrespi/MyRespiLensDashboard.jsx
+++ b/app/src/components/myrespi/MyRespiLensDashboard.jsx
@@ -1194,11 +1194,12 @@ const MyRespiVisualizationPanel = ({
     error: null,
     locationFile: null,
   });
-  const [selectedSubmittedModels, setSelectedSubmittedModels] = useState([]);
+  const [preferredSubmittedModels, setPreferredSubmittedModels] = useState([]);
   const plotRef = useRef(null);
   const isResettingRef = useRef(false);
   const comparisonCacheRef = useRef(new Map());
   const userModelOrderRef = useRef([]);
+  const submittedModelOrderRef = useRef([]);
 
   const locationOptions = useMemo(
     () => buildLocationOptions(projectionOutputs),
@@ -1414,18 +1415,30 @@ const MyRespiVisualizationPanel = ({
     });
   }, [models]);
 
-  useEffect(() => {
+  const selectedSubmittedModels = useMemo(() => {
     if (!submittedModels.length) {
-      setSelectedSubmittedModels([]);
-      return;
+      return [];
     }
-    setSelectedSubmittedModels((current) => {
-      const stillValid = current.filter((model) =>
-        submittedModels.includes(model),
-      );
-      return stillValid.length ? stillValid : [submittedModels[0]];
-    });
-  }, [submittedModels]);
+
+    const stillValid = preferredSubmittedModels.filter((model) =>
+      submittedModels.includes(model),
+    );
+
+    return stillValid.length ? stillValid : [submittedModels[0]];
+  }, [preferredSubmittedModels, submittedModels]);
+
+  const handleSubmittedModelSelectionChange = useCallback((nextModels) => {
+    setPreferredSubmittedModels(nextModels);
+  }, []);
+
+  const stableSubmittedModelOrder = useMemo(() => {
+    const nextOrder = extendStableModelOrder(
+      submittedModelOrderRef.current,
+      selectedSubmittedModels,
+    );
+    submittedModelOrderRef.current = nextOrder;
+    return nextOrder;
+  }, [selectedSubmittedModels]);
 
   const stableUserModelOrder = useMemo(() => {
     const nextOrder = extendStableModelOrder(
@@ -1458,15 +1471,15 @@ const MyRespiVisualizationPanel = ({
   }, [selectedModels, stableUserModelOrder]);
 
   const submittedModelColorFn = useCallback(
-    (model, submittedSelection, submittedModelOrder = submittedSelection) => {
-      const index = submittedModelOrder.indexOf(model);
+    (model) => {
+      const index = stableSubmittedModelOrder.indexOf(model);
       if (index < 0) {
         return null;
       }
 
       return submittedModelPalette[index % submittedModelPalette.length];
     },
-    [submittedModelPalette],
+    [stableSubmittedModelOrder, submittedModelPalette],
   );
 
   const availableDates = useMemo(
@@ -1557,6 +1570,7 @@ const MyRespiVisualizationPanel = ({
     show50: true,
     show95: true,
     modelColorFn: submittedModelColorFn,
+    modelOrder: stableSubmittedModelOrder,
     modelHoverBuilder: buildComparisonHoverText,
     transformY: sqrtTransform,
   });
@@ -1912,7 +1926,7 @@ const MyRespiVisualizationPanel = ({
               <ModelSelector
                 models={submittedModels}
                 selectedModels={selectedSubmittedModels}
-                setSelectedModels={setSelectedSubmittedModels}
+                setSelectedModels={handleSubmittedModelSelectionChange}
                 activeModels={activeSubmittedModels}
                 modelColorFn={submittedModelColorFn}
               />

--- a/app/src/components/myrespi/MyRespiLensDashboard.jsx
+++ b/app/src/components/myrespi/MyRespiLensDashboard.jsx
@@ -13,6 +13,7 @@ import {
   Select,
   SimpleGrid,
   Stack,
+  Switch,
   Text,
   ThemeIcon,
   Tooltip,
@@ -36,9 +37,9 @@ import ModelSelector from "../ModelSelector";
 import ForecastChartControls from "../controls/ForecastChartControls";
 import Seo from "../Seo";
 import useQuantileForecastTraces from "../../hooks/useQuantileForecastTraces";
+import { MODEL_COLORS } from "../../config/datasets";
 import { CHART_CONSTANTS } from "../../constants/chart";
 import { buildSqrtTicks } from "../../utils/scaleUtils";
-import {} from "../../utils/mapUtils";
 
 const HUB_OPTIONS = [
   {
@@ -125,6 +126,8 @@ const normalizeDateString = (value) => {
   }
   return date.toISOString().slice(0, 10);
 };
+
+const getTodayDateString = () => new Date().toISOString().slice(0, 10);
 
 const buildRequiredColumnError = (fileLabel, missingColumns) =>
   `${fileLabel} is missing required columns: ${missingColumns.join(", ")}.`;
@@ -250,6 +253,15 @@ const loadHubReferenceData = async (hubConfig) => {
     );
     return { locations, timeSeries };
   }
+};
+
+const fetchProjectionJson = async (path) => {
+  const response = await fetch(path);
+  if (!response.ok) {
+    throw new Error(`Could not load projections JSON from ${path}.`);
+  }
+
+  return response.json();
 };
 
 const parseCsv = (text) => {
@@ -599,6 +611,26 @@ const buildHubPathogenWarning = (forecastRows, hubConfig) => {
   }
 
   return `Your uploaded target names do not appear to mention "${expectedKeyword}". Please double-check your hub selection.`;
+};
+
+const buildComparisonEligibility = (forecastRows) => {
+  const today = getTodayDateString();
+  const hasPresentOrFutureTargets = forecastRows.some(
+    (row) => String(row.target_end_date) >= today,
+  );
+
+  if (hasPresentOrFutureTargets) {
+    return {
+      isEligible: false,
+      reason:
+        "You can only compare with submitting models when your model data is for the past.",
+    };
+  }
+
+  return {
+    isEligible: true,
+    reason: null,
+  };
 };
 
 const buildGroundTruthOutput = (
@@ -1036,6 +1068,92 @@ const getModelsForTarget = (locationData, target) => {
   return [...modelSet].sort();
 };
 
+const buildComparisonHoverText = ({
+  model,
+  pointDate,
+  formattedMedian,
+  formattedIntervals,
+  issuedDate,
+}) => {
+  const rows = [`<b>Submitted model: ${model}</b><br>Date: ${pointDate}<br>`];
+
+  if (formattedMedian !== null) {
+    rows.push(`Median: <b>${formattedMedian}</b><br>`);
+  }
+
+  formattedIntervals.forEach((interval) => {
+    rows.push(`${interval.label}: [${interval.formattedRange}]<br>`);
+  });
+
+  rows.push(
+    `<span style="color: rgba(255,255,255,0.8); font-size: 0.8em">submitted as of ${issuedDate}</span><extra></extra>`,
+  );
+
+  return rows.join("");
+};
+
+const lightenHexColor = (hexColor, factor = 0.4) => {
+  if (!/^#[0-9a-f]{6}$/i.test(hexColor)) {
+    return hexColor;
+  }
+
+  const red = Number.parseInt(hexColor.slice(1, 3), 16);
+  const green = Number.parseInt(hexColor.slice(3, 5), 16);
+  const blue = Number.parseInt(hexColor.slice(5, 7), 16);
+
+  const lightenChannel = (channel) =>
+    Math.round(channel + (255 - channel) * factor)
+      .toString(16)
+      .padStart(2, "0");
+
+  return `#${lightenChannel(red)}${lightenChannel(green)}${lightenChannel(blue)}`;
+};
+
+const getSubmittedModelColor = (model, selectedModels) => {
+  const index = selectedModels.indexOf(model);
+  if (index < 0) {
+    return null;
+  }
+
+  const offsetIndex =
+    (index + Math.ceil(MODEL_COLORS.length / 2)) % MODEL_COLORS.length;
+  const baseColor = MODEL_COLORS[offsetIndex];
+  return lightenHexColor(baseColor, 0.2);
+};
+
+const filterComparisonLocationData = (
+  comparisonLocationData,
+  userLocationData,
+) => {
+  if (!comparisonLocationData?.forecasts || !userLocationData?.forecasts) {
+    return comparisonLocationData;
+  }
+
+  const filteredForecasts = {};
+
+  Object.entries(userLocationData.forecasts).forEach(([date, targetData]) => {
+    const comparisonDateData = comparisonLocationData.forecasts?.[date];
+    if (!comparisonDateData) {
+      return;
+    }
+
+    Object.keys(targetData || {}).forEach((target) => {
+      const comparisonTargetData = comparisonDateData[target];
+      if (!comparisonTargetData) {
+        return;
+      }
+
+      filteredForecasts[date] ??= {};
+      filteredForecasts[date][target] = comparisonTargetData;
+    });
+  });
+
+  return {
+    ...comparisonLocationData,
+    forecasts: filteredForecasts,
+  };
+};
+
 const getDefaultViewerRange = (
   groundTruthDates,
   selectedDates,
@@ -1078,7 +1196,11 @@ const getDefaultViewerRange = (
   ];
 };
 
-const MyRespiVisualizationPanel = ({ projectionOutputs, hubConfig }) => {
+const MyRespiVisualizationPanel = ({
+  projectionOutputs,
+  hubConfig,
+  comparisonEligibility,
+}) => {
   const { colorScheme } = useMantineColorScheme();
   const isMetrocast = hubConfig?.slug === "flumetrocast";
   const [selectedMetroState, setSelectedMetroState] = useState(null);
@@ -1092,8 +1214,18 @@ const MyRespiVisualizationPanel = ({ projectionOutputs, hubConfig }) => {
   const [showLegend, setShowLegend] = useState(true);
   const [xAxisRange, setXAxisRange] = useState(null);
   const [yAxisRange, setYAxisRange] = useState(null);
+  const [compareWithSubmittingModels, setCompareWithSubmittingModels] =
+    useState(false);
+  const [comparisonDataState, setComparisonDataState] = useState({
+    status: "idle",
+    data: null,
+    error: null,
+    locationFile: null,
+  });
+  const [selectedSubmittedModels, setSelectedSubmittedModels] = useState([]);
   const plotRef = useRef(null);
   const isResettingRef = useRef(false);
+  const comparisonCacheRef = useRef(new Map());
 
   const locationOptions = useMemo(
     () => buildLocationOptions(projectionOutputs),
@@ -1158,6 +1290,90 @@ const MyRespiVisualizationPanel = ({ projectionOutputs, hubConfig }) => {
     [metroHierarchy, selectedMetroState],
   );
 
+  useEffect(() => {
+    if (!comparisonEligibility?.isEligible) {
+      setCompareWithSubmittingModels(false);
+    }
+  }, [comparisonEligibility]);
+
+  useEffect(() => {
+    if (!compareWithSubmittingModels || !selectedLocationFile) {
+      setComparisonDataState({
+        status: "idle",
+        data: null,
+        error: null,
+        locationFile: selectedLocationFile,
+      });
+      return;
+    }
+
+    const cachedData = comparisonCacheRef.current.get(selectedLocationFile);
+    if (cachedData) {
+      setComparisonDataState({
+        status: "success",
+        data: cachedData,
+        error: null,
+        locationFile: selectedLocationFile,
+      });
+      return;
+    }
+
+    let cancelled = false;
+    const comparisonPath = `/processed_data/${hubConfig.slug}/${selectedLocationFile}`;
+
+    setComparisonDataState({
+      status: "loading",
+      data: null,
+      error: null,
+      locationFile: selectedLocationFile,
+    });
+
+    fetchProjectionJson(comparisonPath)
+      .then((data) => {
+        if (cancelled) {
+          return;
+        }
+
+        comparisonCacheRef.current.set(selectedLocationFile, data);
+        setComparisonDataState({
+          status: "success",
+          data,
+          error: null,
+          locationFile: selectedLocationFile,
+        });
+      })
+      .catch((error) => {
+        if (cancelled) {
+          return;
+        }
+
+        setComparisonDataState({
+          status: "error",
+          data: null,
+          error:
+            error instanceof Error
+              ? error.message
+              : "Could not load submitted model comparison data.",
+          locationFile: selectedLocationFile,
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [compareWithSubmittingModels, hubConfig.slug, selectedLocationFile]);
+
+  const comparisonLocationData =
+    compareWithSubmittingModels &&
+    comparisonDataState.status === "success" &&
+    comparisonDataState.locationFile === selectedLocationFile
+      ? comparisonDataState.data
+      : null;
+  const filteredComparisonLocationData = useMemo(
+    () => filterComparisonLocationData(comparisonLocationData, locationData),
+    [comparisonLocationData, locationData],
+  );
+
   const targetOptions = useMemo(
     () => getTargetOptions(locationData),
     [locationData],
@@ -1209,6 +1425,10 @@ const MyRespiVisualizationPanel = ({ projectionOutputs, hubConfig }) => {
     () => getModelsForTarget(locationData, selectedTarget),
     [locationData, selectedTarget],
   );
+  const submittedModels = useMemo(
+    () => getModelsForTarget(filteredComparisonLocationData, selectedTarget),
+    [filteredComparisonLocationData, selectedTarget],
+  );
 
   useEffect(() => {
     if (!models.length) {
@@ -1220,6 +1440,19 @@ const MyRespiVisualizationPanel = ({ projectionOutputs, hubConfig }) => {
       return stillValid.length ? stillValid : [models[0]];
     });
   }, [models]);
+
+  useEffect(() => {
+    if (!submittedModels.length) {
+      setSelectedSubmittedModels([]);
+      return;
+    }
+    setSelectedSubmittedModels((current) => {
+      const stillValid = current.filter((model) =>
+        submittedModels.includes(model),
+      );
+      return stillValid.length ? stillValid : [submittedModels[0]];
+    });
+  }, [submittedModels]);
 
   const availableDates = useMemo(
     () => getAllForecastDates(projectionOutputs),
@@ -1257,6 +1490,25 @@ const MyRespiVisualizationPanel = ({ projectionOutputs, hubConfig }) => {
 
     return activeModelSet;
   }, [locationData, selectedTarget, selectedDates]);
+  const activeSubmittedModels = useMemo(() => {
+    const activeModelSet = new Set();
+    if (
+      !filteredComparisonLocationData?.forecasts ||
+      !selectedTarget ||
+      !selectedDates.length
+    ) {
+      return activeModelSet;
+    }
+
+    selectedDates.forEach((date) => {
+      const targetData =
+        filteredComparisonLocationData.forecasts?.[date]?.[selectedTarget];
+      if (!targetData) return;
+      Object.keys(targetData).forEach((model) => activeModelSet.add(model));
+    });
+
+    return activeModelSet;
+  }, [filteredComparisonLocationData, selectedTarget, selectedDates]);
 
   const sqrtTransform = useMemo(() => {
     if (chartScale !== "sqrt") return null;
@@ -1276,6 +1528,42 @@ const MyRespiVisualizationPanel = ({ projectionOutputs, hubConfig }) => {
     intervalVisibility,
     transformY: sqrtTransform,
   });
+  const {
+    traces: submittedModelTraceBundle,
+    rawYRange: submittedModelRawYRange,
+  } = useQuantileForecastTraces({
+    groundTruth: locationData?.ground_truth,
+    forecasts: filteredComparisonLocationData?.forecasts,
+    selectedDates,
+    selectedModels: selectedSubmittedModels,
+    target: selectedTarget,
+    showLegendForFirstDate: showLegend,
+    showMedian: true,
+    show50: true,
+    show95: true,
+    modelColorFn: getSubmittedModelColor,
+    modelHoverBuilder: buildComparisonHoverText,
+    transformY: sqrtTransform,
+  });
+  const submittedModelTraces = useMemo(
+    () => submittedModelTraceBundle.slice(1),
+    [submittedModelTraceBundle],
+  );
+  const allTraces = useMemo(
+    () => [...traces, ...submittedModelTraces],
+    [submittedModelTraces, traces],
+  );
+  const combinedRawYRange = useMemo(() => {
+    const ranges = [rawYRange, submittedModelRawYRange].filter(Boolean);
+    if (!ranges.length) {
+      return null;
+    }
+
+    return [
+      Math.min(...ranges.map((range) => range[0])),
+      Math.max(...ranges.map((range) => range[1])),
+    ];
+  }, [rawYRange, submittedModelRawYRange]);
 
   const calculateYRange = useCallback((chartData, currentXRange) => {
     if (
@@ -1334,17 +1622,17 @@ const MyRespiVisualizationPanel = ({ projectionOutputs, hubConfig }) => {
       return;
     }
     const currentRange = xAxisRange || defaultRange;
-    if (traces.length > 0 && currentRange) {
-      setYAxisRange(calculateYRange(traces, currentRange));
+    if (allTraces.length > 0 && currentRange) {
+      setYAxisRange(calculateYRange(allTraces, currentRange));
     } else {
       setYAxisRange(null);
     }
-  }, [traces, xAxisRange, defaultRange, calculateYRange, chartScale]);
+  }, [allTraces, xAxisRange, defaultRange, calculateYRange, chartScale]);
 
   const sqrtTicks = useMemo(() => {
     if (chartScale !== "sqrt") return null;
-    return buildSqrtTicks({ rawRange: rawYRange });
-  }, [chartScale, rawYRange]);
+    return buildSqrtTicks({ rawRange: combinedRawYRange });
+  }, [chartScale, combinedRawYRange]);
 
   const handlePlotUpdate = useCallback((figure) => {
     if (isResettingRef.current) {
@@ -1442,7 +1730,7 @@ const MyRespiVisualizationPanel = ({ projectionOutputs, hubConfig }) => {
             const nextYRange =
               chartScale === "log" || !range
                 ? null
-                : calculateYRange(traces, range);
+                : calculateYRange(allTraces, range);
             isResettingRef.current = true;
             setXAxisRange(null);
             setYAxisRange(nextYRange);
@@ -1455,7 +1743,7 @@ const MyRespiVisualizationPanel = ({ projectionOutputs, hubConfig }) => {
         },
       ],
     }),
-    [locationData, selectedDates, chartScale, calculateYRange, traces],
+    [allTraces, locationData, selectedDates, chartScale, calculateYRange],
   );
 
   if ((!isMetrocast && !locationOptions.length) || !locationData) {
@@ -1518,7 +1806,7 @@ const MyRespiVisualizationPanel = ({ projectionOutputs, hubConfig }) => {
         <Paper withBorder radius="md" p="sm">
           <Stack gap="sm">
             <Text fw={600} size="sm">
-              Advanced controls
+              Advanced controls (your model(s))
             </Text>
             <ForecastChartControls
               chartScale={chartScale}
@@ -1529,6 +1817,49 @@ const MyRespiVisualizationPanel = ({ projectionOutputs, hubConfig }) => {
               setShowLegend={setShowLegend}
               intervalOptions={intervalOptions}
             />
+          </Stack>
+        </Paper>
+
+        <Paper withBorder radius="md" p="sm">
+          <Stack gap="xs">
+            <Group justify="space-between" align="center">
+              <Text fw={600} size="sm">
+                Compare with submitting models
+              </Text>
+              <Switch
+                checked={compareWithSubmittingModels}
+                onChange={(event) =>
+                  setCompareWithSubmittingModels(event.currentTarget.checked)
+                }
+                disabled={!comparisonEligibility?.isEligible}
+                size="sm"
+              />
+            </Group>
+            <Text size="sm" c="dimmed">
+              {comparisonEligibility?.isEligible
+                ? "Load submitted model forecasts for the same past issue dates and location."
+                : comparisonEligibility?.reason}
+            </Text>
+            {compareWithSubmittingModels &&
+              comparisonDataState.status === "loading" && (
+                <Group gap="xs">
+                  <Loader size="sm" color="blue" />
+                  <Text size="sm" c="dimmed">
+                    Loading submitted model data for this location...
+                  </Text>
+                </Group>
+              )}
+            {compareWithSubmittingModels &&
+              comparisonDataState.status === "error" && (
+                <Alert
+                  color="red"
+                  variant="light"
+                  radius="md"
+                  icon={<IconAlertCircle size={16} />}
+                >
+                  {comparisonDataState.error}
+                </Alert>
+              )}
           </Stack>
         </Paper>
 
@@ -1551,7 +1882,7 @@ const MyRespiVisualizationPanel = ({ projectionOutputs, hubConfig }) => {
             ref={plotRef}
             useResizeHandler
             style={{ width: "100%", height: "100%" }}
-            data={traces}
+            data={allTraces}
             layout={layout}
             config={config}
             onRelayout={handlePlotUpdate}
@@ -1564,6 +1895,22 @@ const MyRespiVisualizationPanel = ({ projectionOutputs, hubConfig }) => {
           setSelectedModels={setSelectedModels}
           activeModels={activeModels}
         />
+
+        {compareWithSubmittingModels &&
+          comparisonDataState.status === "success" && (
+            <Stack gap="xs">
+              <Text fw={600} size="sm">
+                Submitted models
+              </Text>
+              <ModelSelector
+                models={submittedModels}
+                selectedModels={selectedSubmittedModels}
+                setSelectedModels={setSelectedSubmittedModels}
+                activeModels={activeSubmittedModels}
+                modelColorFn={getSubmittedModelColor}
+              />
+            </Stack>
+          )}
       </Stack>
     </Paper>
   );
@@ -1695,6 +2042,7 @@ const HubUploadScreen = () => {
     status: "idle",
     outputs: null,
     error: null,
+    comparisonEligibility: null,
   });
   const [referenceDataState, setReferenceDataState] = useState({
     status: "idle",
@@ -1711,6 +2059,7 @@ const HubUploadScreen = () => {
       status: "idle",
       outputs: null,
       error: null,
+      comparisonEligibility: null,
     });
     referenceDataPromiseRef.current = null;
     setReferenceDataState({
@@ -1799,6 +2148,7 @@ const HubUploadScreen = () => {
           status: "idle",
           outputs: null,
           error: null,
+          comparisonEligibility: null,
         });
         setPathogenWarning(null);
         setIsUploadProcessing(false);
@@ -1811,6 +2161,7 @@ const HubUploadScreen = () => {
         status: "idle",
         outputs: null,
         error: null,
+        comparisonEligibility: null,
       });
 
       try {
@@ -1882,6 +2233,7 @@ const HubUploadScreen = () => {
             outputs: null,
             error:
               "This hub's time-series file was found, but it is not currently in a CSV format the frontend can process.",
+            comparisonEligibility: null,
           });
           return;
         }
@@ -1897,6 +2249,9 @@ const HubUploadScreen = () => {
           status: "success",
           outputs,
           error: null,
+          comparisonEligibility: buildComparisonEligibility(
+            validation.usableRows,
+          ),
         });
         setIsUploadProcessing(false);
       } catch (error) {
@@ -1910,6 +2265,7 @@ const HubUploadScreen = () => {
           status: "error",
           outputs: null,
           error: message,
+          comparisonEligibility: null,
         });
 
         setValidationState((previousState) =>
@@ -1964,6 +2320,7 @@ const HubUploadScreen = () => {
       status: "idle",
       outputs: null,
       error: null,
+      comparisonEligibility: null,
     });
   }, []);
 
@@ -2059,6 +2416,9 @@ const HubUploadScreen = () => {
               <MyRespiVisualizationPanel
                 projectionOutputs={projectionBuildState.outputs}
                 hubConfig={hubConfig}
+                comparisonEligibility={
+                  projectionBuildState.comparisonEligibility
+                }
               />
             </>
           )}

--- a/app/src/components/views/FluView.jsx
+++ b/app/src/components/views/FluView.jsx
@@ -1,11 +1,12 @@
-import { useMemo, useCallback } from "react";
+import { useMemo, useCallback, useRef } from "react";
 import ForecastPlotView from "../ForecastPlotView";
 import FluPeak from "../FluPeak";
 import TitleRow from "../TitleRow";
-import { MODEL_COLORS } from "../../config/datasets";
+import { getModelColor } from "../../config/datasets";
 import { RATE_CHANGE_CATEGORIES } from "../../constants/chart";
 import { useView } from "../../hooks/useView";
 import { getDatasetTitleFromView } from "../../utils/datasetUtils";
+import { extendStableModelOrder } from "../../utils/modelColorUtils";
 
 const FluView = ({
   data,
@@ -25,6 +26,15 @@ const FluView = ({
 }) => {
   const { chartScale, intervalVisibility, showLegend } = useView();
   const forecasts = data?.forecasts;
+  const stableModelOrderRef = useRef([]);
+  const stableModelOrder = useMemo(() => {
+    const nextOrder = extendStableModelOrder(
+      stableModelOrderRef.current,
+      selectedModels,
+    );
+    stableModelOrderRef.current = nextOrder;
+    return nextOrder;
+  }, [selectedModels]);
 
   const lastSelectedDate = useMemo(() => {
     if (selectedDates.length === 0) return null;
@@ -41,8 +51,7 @@ const FluView = ({
         if (!forecast) return null;
         const horizon0 = forecast.predictions["0"];
         if (!horizon0) return null;
-        const modelColor =
-          MODEL_COLORS[selectedModels.indexOf(model) % MODEL_COLORS.length];
+        const modelColor = getModelColor(model, stableModelOrder);
         const orderedData = categoryOrder.map((cat) => ({
           category: cat.replace("_", "<br>"),
           value:
@@ -65,7 +74,13 @@ const FluView = ({
         };
       })
       .filter(Boolean);
-  }, [forecasts, selectedDates, selectedModels, lastSelectedDate]);
+  }, [
+    forecasts,
+    selectedDates,
+    selectedModels,
+    lastSelectedDate,
+    stableModelOrder,
+  ]);
 
   const extraTraces = useMemo(() => {
     if (viewType !== "fludetailed") return [];

--- a/app/src/components/views/MetroCastView.jsx
+++ b/app/src/components/views/MetroCastView.jsx
@@ -14,7 +14,6 @@ import Plot from "react-plotly.js";
 import ModelSelector from "../ModelSelector";
 import TitleRow from "../TitleRow";
 import { useView } from "../../hooks/useView";
-import { MODEL_COLORS } from "../../config/datasets";
 import { CHART_CONSTANTS } from "../../constants/chart";
 import {
   targetDisplayNameMap,
@@ -483,9 +482,6 @@ const MetroCastView = ({
           selectedModels={selectedModels}
           setSelectedModels={setSelectedModels}
           activeModels={activeModels}
-          getModelColor={(m, sel) =>
-            MODEL_COLORS[sel.indexOf(m) % MODEL_COLORS.length]
-          }
         />
       </Stack>
     </Stack>

--- a/app/src/hooks/useQuantileForecastTraces.js
+++ b/app/src/hooks/useQuantileForecastTraces.js
@@ -1,5 +1,6 @@
-import { useMemo } from "react";
-import { MODEL_COLORS } from "../config/datasets";
+import { useMemo, useRef } from "react";
+import { MODEL_COLORS, getModelColor } from "../config/datasets";
+import { extendStableModelOrder } from "../utils/modelColorUtils";
 
 const defaultFormatValue = (value) =>
   value.toLocaleString(undefined, { maximumFractionDigits: 2 });
@@ -48,11 +49,6 @@ const buildDefaultModelHoverText = ({
   return rows.join("");
 };
 
-const resolveModelColor = (selectedModels, model) => {
-  const index = selectedModels.indexOf(model);
-  return MODEL_COLORS[index % MODEL_COLORS.length];
-};
-
 const findQuantileValue = (quantiles, values, requestedQuantile) => {
   const index = quantiles.findIndex(
     (quantile) => Number(quantile) === requestedQuantile,
@@ -86,6 +82,7 @@ const useQuantileForecastTraces = ({
   formatValue = defaultFormatValue,
   modelHoverBuilder = null,
   modelColorFn = null,
+  modelOrder = null,
   modelLineWidth = 2,
   modelMarkerSize = 6,
   groundTruthLineWidth = 2,
@@ -99,8 +96,18 @@ const useQuantileForecastTraces = ({
   intervalVisibility = null,
   transformY = null,
   groundTruthHoverFormatter = null,
-}) =>
-  useMemo(() => {
+}) => {
+  const stableModelOrderRef = useRef([]);
+  const stableModelOrder = useMemo(() => {
+    const nextOrder = extendStableModelOrder(
+      stableModelOrderRef.current,
+      selectedModels,
+    );
+    stableModelOrderRef.current = nextOrder;
+    return nextOrder;
+  }, [selectedModels]);
+
+  return useMemo(() => {
     if (!groundTruth || !forecasts || selectedDates.length === 0 || !target) {
       return { traces: [], rawYRange: null };
     }
@@ -285,8 +292,9 @@ const useQuantileForecastTraces = ({
         if (forecastDates.length === 0 && !hasIntervalSeries) return [];
 
         const modelColor = modelColorFn
-          ? modelColorFn(model, selectedModels)
-          : resolveModelColor(selectedModels, model);
+          ? modelColorFn(model, selectedModels, modelOrder ?? stableModelOrder)
+          : (getModelColor(model, modelOrder ?? stableModelOrder) ??
+            MODEL_COLORS[0]);
         const isFirstDate = dateIndex === 0;
 
         const traces = [];
@@ -372,6 +380,7 @@ const useQuantileForecastTraces = ({
     formatValue,
     modelHoverBuilder,
     modelColorFn,
+    modelOrder,
     modelLineWidth,
     modelMarkerSize,
     groundTruthLineWidth,
@@ -385,6 +394,8 @@ const useQuantileForecastTraces = ({
     intervalVisibility,
     transformY,
     groundTruthHoverFormatter,
+    stableModelOrder,
   ]);
+};
 
 export default useQuantileForecastTraces;

--- a/app/src/theme/mantine.js
+++ b/app/src/theme/mantine.js
@@ -25,8 +25,8 @@ export const MODEL_COLORS = [
 ];
 
 // Model color helper function
-export const getModelColor = (model, selectedModels) => {
-  const index = selectedModels.indexOf(model);
+export const getModelColor = (model, modelOrder = []) => {
+  const index = modelOrder.indexOf(model);
   return index >= 0 ? MODEL_COLORS[index % MODEL_COLORS.length] : null;
 };
 

--- a/app/src/utils/modelColorUtils.js
+++ b/app/src/utils/modelColorUtils.js
@@ -1,0 +1,21 @@
+import { MODEL_COLORS } from "../config/datasets";
+
+export const extendStableModelOrder = (
+  previousOrder = [],
+  selectedModels = [],
+) => {
+  const nextOrder = [...previousOrder];
+
+  selectedModels.forEach((model) => {
+    if (!nextOrder.includes(model)) {
+      nextOrder.push(model);
+    }
+  });
+
+  return nextOrder;
+};
+
+export const getStablePaletteColor = (model, modelOrder = []) => {
+  const index = modelOrder.indexOf(model);
+  return index >= 0 ? MODEL_COLORS[index % MODEL_COLORS.length] : undefined;
+};


### PR DESCRIPTION
- if user-uploaded model data is in the past, there is now a clickable switch that allows you to compare with other models that have submitted to the hub
- colors interact well + are static, legend shows name, models don't switch if you change locations ✅
    - fixed general suboptimal behavior of model selector; now if you de-select models none of the colors change
- removed the alpha release notations of MyPlots 

merging into the `myrespi-overhaul` branch, which will be merged into main upon Joseph's return 