### PR TITLE
Better URL scheme

### DIFF
--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -50,6 +50,13 @@ const AppLayout = () => {
     <UnifiedAppShell>
       <Routes>
         <Route path="/" element={<ForecastApp />} />
+        <Route path="/forecasts" element={<Navigate to="/" replace />} />
+        <Route path="/forecasts/*" element={<ForecastApp />} />
+        <Route
+          path="/surveillance"
+          element={<Navigate to="/surveillance/nhsn" replace />}
+        />
+        <Route path="/surveillance/*" element={<ForecastApp />} />
         <Route
           path="/narratives"
           element={

--- a/app/src/components/FrontPage.jsx
+++ b/app/src/components/FrontPage.jsx
@@ -35,7 +35,7 @@ const NsspViewLink = () => {
     <span>
       Check out our new{" "}
       <Anchor
-        href="/?view=nsspall"
+        href="/surveillance/nssp"
         fw={700}
         c="blue.7"
         style={{ fontSize: "inherit", verticalAlign: "baseline" }}

--- a/app/src/components/layout/MainNavigation.jsx
+++ b/app/src/components/layout/MainNavigation.jsx
@@ -24,7 +24,10 @@ const MainNavigation = () => {
       href: "/",
       label: "Forecasts",
       icon: IconChartLine,
-      active: location.pathname === "/",
+      active:
+        location.pathname === "/" ||
+        location.pathname.startsWith("/forecasts") ||
+        location.pathname.startsWith("/surveillance"),
     },
     // { href: '/narratives', label: 'Narratives', icon: IconBook, active: isActive('/narratives') },   disable narratives for now
     {

--- a/app/src/components/layout/UnifiedAppShell.jsx
+++ b/app/src/components/layout/UnifiedAppShell.jsx
@@ -22,7 +22,11 @@ import StateSelector from "../StateSelector";
 
 const getShellConfig = (pathname) => {
   // For forecast view (main page), show navbar with StateSelector
-  if (pathname === "/") {
+  if (
+    pathname === "/" ||
+    pathname.startsWith("/forecasts") ||
+    pathname.startsWith("/surveillance")
+  ) {
     return {
       type: "forecast",
       header: { height: 60 },
@@ -71,7 +75,10 @@ const UnifiedAppShell = ({ children, forecastProps = {} }) => {
       href: "/",
       label: "Forecasts",
       icon: IconChartLine,
-      active: location.pathname === "/",
+      active:
+        location.pathname === "/" ||
+        location.pathname.startsWith("/forecasts") ||
+        location.pathname.startsWith("/surveillance"),
     },
     {
       href: "/forecastle",

--- a/app/src/contexts/ViewContext.jsx
+++ b/app/src/contexts/ViewContext.jsx
@@ -1,10 +1,17 @@
 import { useState, useCallback, useEffect, useMemo } from "react";
-import { useLocation, useSearchParams } from "react-router-dom";
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { URLParameterManager } from "../utils/urlManager";
 import { useForecastData } from "../hooks/useForecastData";
 import { ViewContext } from "./ViewContextObject";
 import { APP_CONFIG, DATASETS } from "../config";
 import { getDataPath } from "../utils/paths";
+import {
+  buildForecastPath,
+  buildForecastUrl,
+  isForecastPathname,
+  isPathBasedForecastView,
+  parseForecastUrlState,
+} from "../utils/forecastRoutes";
 
 const METRO_STATE_MAP = {
   Colorado: "CO",
@@ -339,17 +346,26 @@ const resolveLocationForView = ({
 export const ViewProvider = ({ children }) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const location = useLocation();
-  const isForecastPage = location.pathname === "/";
+  const navigate = useNavigate();
+  const isForecastPage = isForecastPathname(location.pathname);
 
   const urlManager = useMemo(
-    () => new URLParameterManager(searchParams, setSearchParams),
-    [searchParams, setSearchParams],
+    () =>
+      new URLParameterManager(
+        searchParams,
+        setSearchParams,
+        location.pathname,
+        navigate,
+      ),
+    [searchParams, setSearchParams, location.pathname, navigate],
   );
 
   const [viewType, setViewTypeState] = useState(() => urlManager.getView());
   const [selectedLocation, setSelectedLocation] = useState(() => {
-    const urlLoc = urlManager.getLocation();
-    const currentView = urlManager.getView();
+    const { location: urlLoc, viewType: currentView } = parseForecastUrlState(
+      location.pathname,
+      searchParams,
+    );
     const dataset = urlManager.getDatasetFromView(currentView);
     if (dataset?.defaultLocation && urlLoc === APP_CONFIG.defaultLocation) {
       return dataset.defaultLocation;
@@ -610,10 +626,16 @@ export const ViewProvider = ({ children }) => {
 
   const handleLocationSelect = (newLocation) => {
     const currentDataset = urlManager.getDatasetFromView(viewType);
-    const effectiveDefault =
-      currentDataset?.defaultLocation || APP_CONFIG.defaultLocation;
     setLocationMessage(null);
-    urlManager.updateLocation(newLocation, effectiveDefault);
+    const nextUrl = buildForecastUrl({
+      viewType,
+      location:
+        newLocation ||
+        currentDataset?.defaultLocation ||
+        APP_CONFIG.defaultLocation,
+      searchParams,
+    });
+    navigate(nextUrl, { replace: true });
     setSelectedLocation(newLocation);
   };
 
@@ -650,21 +672,6 @@ export const ViewProvider = ({ children }) => {
       setLocationMessage(nextLocationMessage);
       setSelectedLocation(nextLocation);
 
-      if (nextLocation && nextLocation !== effectiveDefault) {
-        newSearchParams.set("location", nextLocation);
-      } else {
-        newSearchParams.delete("location");
-      }
-
-      if (
-        newView !== APP_CONFIG.defaultView ||
-        newSearchParams.toString().length > 0
-      ) {
-        newSearchParams.set("view", newView);
-      } else {
-        newSearchParams.delete("view");
-      }
-
       const isDatasetChange = oldDataset?.shortName !== newDataset?.shortName;
       const isPeakTransition = oldView === "flu_peak" || newView === "flu_peak";
 
@@ -695,7 +702,12 @@ export const ViewProvider = ({ children }) => {
       }
 
       setViewTypeState(newView);
-      setSearchParams(newSearchParams, { replace: false });
+      const nextUrl = buildForecastUrl({
+        viewType: newView,
+        location: nextLocation || effectiveDefault,
+        searchParams: newSearchParams,
+      });
+      navigate(nextUrl, { replace: false });
     },
     [
       viewType,
@@ -704,7 +716,7 @@ export const ViewProvider = ({ children }) => {
       selectedLocation,
       data,
       locationCatalogs,
-      setSearchParams,
+      navigate,
     ],
   );
 
@@ -755,7 +767,12 @@ export const ViewProvider = ({ children }) => {
     }
 
     setSelectedLocation(resolution.nextLocation);
-    urlManager.updateLocation(resolution.nextLocation, effectiveDefault);
+    const nextUrl = buildForecastUrl({
+      viewType,
+      location: resolution.nextLocation,
+      searchParams,
+    });
+    navigate(nextUrl, { replace: true });
   }, [
     isForecastPage,
     viewType,
@@ -763,6 +780,8 @@ export const ViewProvider = ({ children }) => {
     data,
     locationCatalogs,
     locationMessage,
+    navigate,
+    searchParams,
     urlManager,
   ]);
 
@@ -771,7 +790,14 @@ export const ViewProvider = ({ children }) => {
     if (viewFromUrl !== viewType) {
       setViewTypeState(viewFromUrl);
     }
-  }, [searchParams, urlManager, viewType]);
+  }, [searchParams, location.pathname, urlManager, viewType]);
+
+  useEffect(() => {
+    const locationFromUrl = urlManager.getLocation();
+    if (locationFromUrl !== selectedLocation) {
+      setSelectedLocation(locationFromUrl);
+    }
+  }, [searchParams, location.pathname, selectedLocation, urlManager]);
 
   useEffect(() => {
     if (!isForecastPage) {
@@ -793,12 +819,37 @@ export const ViewProvider = ({ children }) => {
     }
   }, [
     searchParams,
+    location.pathname,
     urlManager,
     isForecastPage,
     chartScale,
     intervalVisibility,
     showLegend,
   ]);
+
+  useEffect(() => {
+    if (location.pathname !== "/") {
+      return;
+    }
+
+    if (!isPathBasedForecastView(viewType)) {
+      return;
+    }
+
+    const nextUrl = buildForecastUrl({
+      viewType,
+      location: selectedLocation,
+      searchParams,
+    });
+    const canonicalPath = buildForecastPath(viewType, selectedLocation);
+
+    if (
+      nextUrl.pathname === canonicalPath &&
+      nextUrl.pathname !== location.pathname
+    ) {
+      navigate(nextUrl, { replace: true });
+    }
+  }, [location.pathname, navigate, searchParams, selectedLocation, viewType]);
 
   const setChartScaleWithUrl = useCallback(
     (nextScale) => {

--- a/app/src/hooks/extractPlotDataFromURL.js
+++ b/app/src/hooks/extractPlotDataFromURL.js
@@ -1,5 +1,6 @@
 import { savePlot } from "../utils/plotStorage";
 import { resolvePlotLocationDisplayName } from "../utils/plotLocationDisplay";
+import { parseForecastUrlState } from "../utils/forecastRoutes";
 
 const NSSP_COLUMN_LABELS = {
   percent_visits_covid: "COVID-19",
@@ -19,6 +20,7 @@ const NSSP_DEFAULT_COLUMNS = Object.keys(NSSP_COLUMN_LABELS);
 export const extractPlotData = (viewType, href, data) => {
   const url = new URL(href);
   const params = url.searchParams;
+  const urlState = parseForecastUrlState(url.pathname, params);
   const id = crypto.randomUUID();
   const currentDate = new Date().toISOString().split("T")[0];
   let dataSuffix = "";
@@ -40,7 +42,7 @@ export const extractPlotData = (viewType, href, data) => {
   switch (viewType) {
     case "covid_forecasts": {
       dataSuffix = "covid19";
-      location = params.has("location") ? params.get("location") : "US";
+      location = urlState.location || "US";
       fileName = `${location}_${dataSuffix}.json`;
       fullDataPath = `covid19forecasthub/${fileName}`;
       target = params.has("covid_target")
@@ -76,7 +78,7 @@ export const extractPlotData = (viewType, href, data) => {
     case "flu_forecasts":
     case "fludetailed": {
       dataSuffix = "flu";
-      location = params.has("location") ? params.get("location") : "US";
+      location = urlState.location || "US";
       fileName = `${location}_${dataSuffix}.json`;
       fullDataPath = `flusight/${fileName}`;
       target = params.has("flu_target")
@@ -111,7 +113,7 @@ export const extractPlotData = (viewType, href, data) => {
 
     case "flu_peak": {
       dataSuffix = "flu";
-      location = params.has("location") ? params.get("location") : "US";
+      location = urlState.location || "US";
       fileName = `${location}_${dataSuffix}.json`;
       fullDataPath = `flusight/${fileName}`;
       target = "Peak flu hospitalizations";
@@ -159,7 +161,7 @@ export const extractPlotData = (viewType, href, data) => {
 
     case "rsv_forecasts": {
       dataSuffix = "rsv";
-      location = params.has("location") ? params.get("location") : "US";
+      location = urlState.location || "US";
       fileName = `${location}_${dataSuffix}.json`;
       fullDataPath = `rsvforecasthub/${fileName}`;
       target = params.has("rsv_target")
@@ -194,7 +196,7 @@ export const extractPlotData = (viewType, href, data) => {
 
     case "metrocast_forecasts": {
       dataSuffix = "flu_metrocast";
-      location = params.has("location") ? params.get("location") : "colorado";
+      location = urlState.location || "colorado";
       fileName = `${location}_${dataSuffix}.json`;
       fullDataPath = `flumetrocast/${fileName}`;
       target = "Flu ED visits pct";
@@ -227,7 +229,7 @@ export const extractPlotData = (viewType, href, data) => {
 
     case "nhsnall": {
       dataSuffix = "nhsn";
-      location = params.has("location") ? params.get("location") : "US";
+      location = urlState.location || "US";
       fileName = `${location}_${dataSuffix}.json`;
       fullDataPath = `nhsn/${fileName}`;
       target = params.has("nhsn_target")
@@ -267,7 +269,7 @@ export const extractPlotData = (viewType, href, data) => {
 
     case "nsspall": {
       dataSuffix = "nssp";
-      location = params.has("location") ? params.get("location") : "US_All";
+      location = urlState.location || "US_All";
       fileName = `${location}_${dataSuffix}.json`;
       fullDataPath = `nssp/${fileName}`;
       target = "Percent of visits";

--- a/app/src/utils/forecastRoutes.js
+++ b/app/src/utils/forecastRoutes.js
@@ -1,0 +1,235 @@
+import { APP_CONFIG, DATASETS } from "../config";
+
+const FORECAST_ROOT = "/forecasts";
+const SURVEILLANCE_ROOT = "/surveillance";
+
+const PATH_VIEW_CONFIG = {
+  covid_forecasts: { pathogen: "covid" },
+  flu_forecasts: { pathogen: "flu" },
+  fludetailed: { pathogen: "flu", variant: "detailed" },
+  flu_peak: { pathogen: "flu", variant: "peak" },
+  rsv_forecasts: { pathogen: "rsv" },
+  metrocast_forecasts: { pathogen: "flu", variant: "metrocast" },
+  nhsnall: { section: "surveillance", source: "nhsn" },
+  nsspall: { section: "surveillance", source: "nssp" },
+};
+
+const PATHOGEN_VARIANT_TO_VIEW = {
+  covid: {
+    default: "covid_forecasts",
+  },
+  flu: {
+    default: "flu_forecasts",
+    detailed: "fludetailed",
+    peak: "flu_peak",
+    metrocast: "metrocast_forecasts",
+  },
+  rsv: {
+    default: "rsv_forecasts",
+  },
+  metrocast: {
+    default: "metrocast_forecasts",
+  },
+};
+
+const SURVEILLANCE_SOURCE_TO_VIEW = {
+  nhsn: "nhsnall",
+  nssp: "nsspall",
+};
+
+const RESERVED_VARIANTS = new Set(["detailed", "peak", "metrocast"]);
+
+const sanitizeLocationSegment = (location) => {
+  if (!location) {
+    return null;
+  }
+
+  return String(location).trim();
+};
+
+export const isPathBasedForecastView = (viewType) =>
+  Object.prototype.hasOwnProperty.call(PATH_VIEW_CONFIG, viewType);
+
+export const isForecastPathname = (pathname = "") =>
+  pathname === "/" ||
+  pathname === FORECAST_ROOT ||
+  pathname.startsWith(`${FORECAST_ROOT}/`) ||
+  pathname === SURVEILLANCE_ROOT ||
+  pathname.startsWith(`${SURVEILLANCE_ROOT}/`);
+
+export const getDefaultLocationForView = (viewType) => {
+  const dataset =
+    Object.values(DATASETS).find((entry) =>
+      entry.views.some((view) => view.value === viewType),
+    ) || null;
+
+  return dataset?.defaultLocation || APP_CONFIG.defaultLocation;
+};
+
+export const buildForecastPath = (viewType, location) => {
+  if (!isPathBasedForecastView(viewType)) {
+    return "/";
+  }
+
+  const config = PATH_VIEW_CONFIG[viewType];
+  const defaultLocation = getDefaultLocationForView(viewType);
+
+  if (config.section === "surveillance") {
+    const segments = [SURVEILLANCE_ROOT, config.source];
+    if (location && location !== defaultLocation) {
+      segments.push(encodeURIComponent(location));
+    }
+    return segments.join("/");
+  }
+
+  const segments = [FORECAST_ROOT, config.pathogen];
+
+  if (config.variant) {
+    segments.push(config.variant);
+  }
+
+  if (location && location !== defaultLocation) {
+    segments.push(encodeURIComponent(location));
+  }
+
+  return segments.join("/");
+};
+
+const parsePathBasedForecastState = (pathname) => {
+  if (pathname.startsWith(SURVEILLANCE_ROOT)) {
+    const trimmedPath = pathname.replace(/\/+$/g, "");
+    const relativePath = trimmedPath
+      .slice(SURVEILLANCE_ROOT.length)
+      .replace(/^\/+/g, "");
+    const segments = relativePath ? relativePath.split("/") : [];
+
+    if (segments.length === 0) {
+      return null;
+    }
+
+    const [source, locationSegment] = segments.map((segment) =>
+      decodeURIComponent(segment),
+    );
+    const viewType = SURVEILLANCE_SOURCE_TO_VIEW[source];
+
+    if (!viewType) {
+      return null;
+    }
+
+    return {
+      viewType,
+      location:
+        sanitizeLocationSegment(locationSegment) ||
+        getDefaultLocationForView(viewType),
+    };
+  }
+
+  const trimmedPath = pathname.replace(/\/+$/g, "");
+  const relativePath = trimmedPath
+    .slice(FORECAST_ROOT.length)
+    .replace(/^\/+/g, "");
+  const segments = relativePath ? relativePath.split("/") : [];
+
+  if (segments.length === 0) {
+    return null;
+  }
+
+  const [pathogen, secondSegment, thirdSegment] = segments.map((segment) =>
+    decodeURIComponent(segment),
+  );
+  const pathogenConfig = PATHOGEN_VARIANT_TO_VIEW[pathogen];
+
+  if (!pathogenConfig) {
+    return null;
+  }
+
+  let viewType = pathogenConfig.default;
+  let location = null;
+
+  if (
+    pathogen === "flu" &&
+    secondSegment &&
+    RESERVED_VARIANTS.has(secondSegment)
+  ) {
+    viewType = pathogenConfig[secondSegment] || pathogenConfig.default;
+    location = sanitizeLocationSegment(thirdSegment);
+  } else if (pathogen === "metrocast") {
+    viewType = "metrocast_forecasts";
+    location = sanitizeLocationSegment(secondSegment);
+  } else if (secondSegment) {
+    location = sanitizeLocationSegment(secondSegment);
+  }
+
+  return {
+    viewType,
+    location: location || getDefaultLocationForView(viewType),
+  };
+};
+
+export const parseForecastUrlState = (pathname, searchParams) => {
+  if (
+    pathname &&
+    (pathname.startsWith(FORECAST_ROOT) ||
+      pathname.startsWith(SURVEILLANCE_ROOT))
+  ) {
+    const pathState = parsePathBasedForecastState(pathname);
+    if (pathState) {
+      return {
+        ...pathState,
+        source: "path",
+      };
+    }
+  }
+
+  const allViews = Object.values(DATASETS).flatMap((dataset) =>
+    dataset.views.map((view) => view.value),
+  );
+  const queryView = searchParams.get("view");
+  const viewType = allViews.includes(queryView)
+    ? queryView
+    : APP_CONFIG.defaultView;
+  const location =
+    searchParams.get("location") || getDefaultLocationForView(viewType);
+
+  return {
+    viewType,
+    location,
+    source: "query",
+  };
+};
+
+export const buildForecastUrl = ({ viewType, location, searchParams }) => {
+  const nextParams = new URLSearchParams(searchParams);
+  nextParams.delete("view");
+  nextParams.delete("location");
+
+  if (viewType === "frontpage") {
+    if (location && location !== APP_CONFIG.defaultLocation) {
+      nextParams.set("location", location);
+    }
+    const search = nextParams.toString();
+    return {
+      pathname: "/",
+      search: search ? `?${search}` : "",
+    };
+  }
+
+  if (isPathBasedForecastView(viewType)) {
+    const search = nextParams.toString();
+    return {
+      pathname: buildForecastPath(viewType, location),
+      search: search ? `?${search}` : "",
+    };
+  }
+
+  const defaultLocation = getDefaultLocationForView(viewType);
+  nextParams.set("view", viewType);
+  if (location && location !== defaultLocation) {
+    nextParams.set("location", location);
+  }
+  const search = nextParams.toString();
+  return {
+    pathname: "/",
+    search: search ? `?${search}` : "",
+  };
+};

--- a/app/src/utils/forecastRoutes.js
+++ b/app/src/utils/forecastRoutes.js
@@ -5,11 +5,11 @@ const SURVEILLANCE_ROOT = "/surveillance";
 
 const PATH_VIEW_CONFIG = {
   covid_forecasts: { pathogen: "covid" },
-  flu_forecasts: { pathogen: "flu" },
-  fludetailed: { pathogen: "flu", variant: "detailed" },
-  flu_peak: { pathogen: "flu", variant: "peak" },
+  flu_forecasts: { pathogen: "flusight" },
+  fludetailed: { pathogen: "flusight", variant: "detailed" },
+  flu_peak: { pathogen: "flusight", variant: "peak" },
   rsv_forecasts: { pathogen: "rsv" },
-  metrocast_forecasts: { pathogen: "flu", variant: "metrocast" },
+  metrocast_forecasts: { pathogen: "flu-metrocast" },
   nhsnall: { section: "surveillance", source: "nhsn" },
   nsspall: { section: "surveillance", source: "nssp" },
 };
@@ -18,17 +18,16 @@ const PATHOGEN_VARIANT_TO_VIEW = {
   covid: {
     default: "covid_forecasts",
   },
-  flu: {
+  flusight: {
     default: "flu_forecasts",
     detailed: "fludetailed",
     peak: "flu_peak",
-    metrocast: "metrocast_forecasts",
+  },
+  "flu-metrocast": {
+    default: "metrocast_forecasts",
   },
   rsv: {
     default: "rsv_forecasts",
-  },
-  metrocast: {
-    default: "metrocast_forecasts",
   },
 };
 
@@ -280,7 +279,7 @@ const parsePathBasedForecastState = (pathname) => {
   let location = null;
 
   if (
-    pathogen === "flu" &&
+    pathogen === "flusight" &&
     secondSegment &&
     RESERVED_VARIANTS.has(secondSegment)
   ) {
@@ -289,7 +288,7 @@ const parsePathBasedForecastState = (pathname) => {
       viewType === "metrocast_forecasts"
         ? deserializeMetrocastLocationFromPath(thirdSegment)
         : sanitizeLocationSegment(thirdSegment);
-  } else if (pathogen === "metrocast") {
+  } else if (pathogen === "flu-metrocast") {
     viewType = "metrocast_forecasts";
     location = deserializeMetrocastLocationFromPath(secondSegment);
   } else if (secondSegment) {

--- a/app/src/utils/forecastRoutes.js
+++ b/app/src/utils/forecastRoutes.js
@@ -39,12 +39,141 @@ const SURVEILLANCE_SOURCE_TO_VIEW = {
 
 const RESERVED_VARIANTS = new Set(["detailed", "peak", "metrocast"]);
 
+const METROCAST_STATE_URL_TO_LOCATION = {
+  CO: "colorado",
+  GA: "georgia",
+  IN: "indiana",
+  ME: "maine",
+  MD: "maryland",
+  MA: "massachusetts",
+  MN: "minnesota",
+  NC: "north-carolina",
+  OR: "oregon",
+  SC: "south-carolina",
+  TX: "texas",
+  UT: "utah",
+  VA: "virginia",
+};
+
+const METROCAST_LOCATION_TO_STATE_URL = Object.fromEntries(
+  Object.entries(METROCAST_STATE_URL_TO_LOCATION).map(
+    ([stateCode, location]) => [location, stateCode],
+  ),
+);
+
+const METROCAST_SUBLOCATION_TO_STATE_URL = {
+  denver: "CO",
+  mesa: "CO",
+  "colorado-springs": "CO",
+  weld: "CO",
+  boulder: "CO",
+  larimer: "CO",
+  savannah: "GA",
+  floyd: "GA",
+  hall: "GA",
+  marietta: "GA",
+  macon: "GA",
+  henry: "GA",
+  cherokee: "GA",
+  athens: "GA",
+  "south-augusta": "GA",
+  columbus: "GA",
+  "la-grange": "GA",
+  indianapolis: "IN",
+  bangor: "ME",
+  portland: "ME",
+  baltimore: "MD",
+  frederick: "MD",
+  montgomery: "MD",
+  harford: "MD",
+  worcester: "MA",
+  pittsfield: "MA",
+  boston: "MA",
+  springfield: "MA",
+  "new-bedford": "MA",
+  lynn: "MA",
+  "st-paul": "MN",
+  duluth: "MN",
+  minneapolis: "MN",
+  "st-cloud": "MN",
+  rochester: "MN",
+  nenc: "NC",
+  senc: "NC",
+  "fay-area": "NC",
+  "rtp-area": "NC",
+  "triad-area": "NC",
+  wnc: "NC",
+  "clt-area": "NC",
+  "portland-or": "OR",
+  salem: "OR",
+  deschutes: "OR",
+  eugene: "OR",
+  medford: "OR",
+  columbia: "SC",
+  greenville: "SC",
+  florence: "SC",
+  charleston: "SC",
+  "rock-hill": "SC",
+  horry: "SC",
+  houston: "TX",
+  "san-antonio": "TX",
+  beaumont: "TX",
+  "el-paso": "TX",
+  austin: "TX",
+  dallas: "TX",
+  provo: "UT",
+  "salt-lake-city": "UT",
+  ogden: "UT",
+  roanoke: "VA",
+  nyc: "NY",
+};
+
 const sanitizeLocationSegment = (location) => {
   if (!location) {
     return null;
   }
 
   return String(location).trim();
+};
+
+const serializeMetrocastLocationForPath = (location) => {
+  if (!location) {
+    return null;
+  }
+
+  const stateCode = METROCAST_LOCATION_TO_STATE_URL[location];
+  if (stateCode) {
+    return stateCode;
+  }
+
+  const parentStateCode = METROCAST_SUBLOCATION_TO_STATE_URL[location];
+  if (parentStateCode) {
+    return `${parentStateCode}_${location}`;
+  }
+
+  return location;
+};
+
+const deserializeMetrocastLocationFromPath = (locationSegment) => {
+  const sanitizedLocation = sanitizeLocationSegment(locationSegment);
+  if (!sanitizedLocation) {
+    return null;
+  }
+
+  if (METROCAST_STATE_URL_TO_LOCATION[sanitizedLocation]) {
+    return METROCAST_STATE_URL_TO_LOCATION[sanitizedLocation];
+  }
+
+  const [stateCode, subLocation] = sanitizedLocation.split(/_(.+)/);
+  if (
+    stateCode &&
+    subLocation &&
+    METROCAST_SUBLOCATION_TO_STATE_URL[subLocation] === stateCode
+  ) {
+    return subLocation;
+  }
+
+  return sanitizedLocation;
 };
 
 export const isPathBasedForecastView = (viewType) =>
@@ -89,7 +218,11 @@ export const buildForecastPath = (viewType, location) => {
   }
 
   if (location && location !== defaultLocation) {
-    segments.push(encodeURIComponent(location));
+    const serializedLocation =
+      viewType === "metrocast_forecasts"
+        ? serializeMetrocastLocationForPath(location)
+        : location;
+    segments.push(encodeURIComponent(serializedLocation));
   }
 
   return segments.join("/");
@@ -152,10 +285,13 @@ const parsePathBasedForecastState = (pathname) => {
     RESERVED_VARIANTS.has(secondSegment)
   ) {
     viewType = pathogenConfig[secondSegment] || pathogenConfig.default;
-    location = sanitizeLocationSegment(thirdSegment);
+    location =
+      viewType === "metrocast_forecasts"
+        ? deserializeMetrocastLocationFromPath(thirdSegment)
+        : sanitizeLocationSegment(thirdSegment);
   } else if (pathogen === "metrocast") {
     viewType = "metrocast_forecasts";
-    location = sanitizeLocationSegment(secondSegment);
+    location = deserializeMetrocastLocationFromPath(secondSegment);
   } else if (secondSegment) {
     location = sanitizeLocationSegment(secondSegment);
   }

--- a/app/src/utils/plotDownloadName.js
+++ b/app/src/utils/plotDownloadName.js
@@ -1,3 +1,5 @@
+import { parseForecastUrlState } from "./forecastRoutes";
+
 const DEFAULT_PREFIX = "respilens";
 const MAX_FILENAME_LENGTH = 120;
 
@@ -21,14 +23,12 @@ export const buildPlotDownloadName = (fallback = "plot") => {
 
   const { pathname, search } = window.location;
   const params = new URLSearchParams(search);
+  const { viewType, location } = parseForecastUrlState(pathname, params);
 
-  const rawView = params.get("view");
-  const rawLocation = params.get("location");
-
-  const viewPart = rawView
-    ? rawView.replace(/_/g, "-")
+  const viewPart = viewType
+    ? viewType.replace(/_/g, "-")
     : pathname.replace(/\/+$/g, "").replace(/^\/+/g, "") || "home";
-  const locationPart = rawLocation ? rawLocation.toLowerCase() : "";
+  const locationPart = location ? location.toLowerCase() : "";
 
   const combined = [DEFAULT_PREFIX, viewPart, locationPart]
     .filter(Boolean)

--- a/app/src/utils/urlManager.js
+++ b/app/src/utils/urlManager.js
@@ -1,4 +1,5 @@
 import { DATASETS, APP_CONFIG } from "../config";
+import { parseForecastUrlState } from "./forecastRoutes";
 
 const DEFAULT_CHART_SCALE = "linear";
 const DEFAULT_INTERVAL_VISIBILITY = {
@@ -9,9 +10,16 @@ const DEFAULT_INTERVAL_VISIBILITY = {
 const DEFAULT_SHOW_LEGEND = true;
 
 export class URLParameterManager {
-  constructor(searchParams, setSearchParams) {
+  constructor(
+    searchParams,
+    setSearchParams,
+    pathname = window.location?.pathname,
+    navigate = null,
+  ) {
     this.searchParams = searchParams;
     this.setSearchParams = setSearchParams;
+    this.pathname = pathname;
+    this.navigate = navigate;
   }
 
   // Get dataset from view type
@@ -228,28 +236,12 @@ export class URLParameterManager {
 
   // Get current location from URL
   getLocation() {
-    return this.searchParams.get("location") || APP_CONFIG.defaultLocation;
+    return parseForecastUrlState(this.pathname, this.searchParams).location;
   }
 
   // Get current view from URL
   getView() {
-    const viewParam = this.searchParams.get("view");
-    const allViews = Object.values(DATASETS).flatMap((ds) =>
-      ds.views.map((v) => v.value),
-    );
-    if (viewParam) {
-      if (viewParam === APP_CONFIG.defaultView) {
-        return viewParam;
-      }
-      if (allViews.includes(viewParam)) {
-        return viewParam;
-      }
-    }
-    if (APP_CONFIG.defaultView) {
-      return APP_CONFIG.defaultView;
-    }
-    const defaultDatasetKey = APP_CONFIG.defaultDataset;
-    return DATASETS[defaultDatasetKey]?.defaultView;
+    return parseForecastUrlState(this.pathname, this.searchParams).viewType;
   }
   initializeDefaults() {}
 }


### PR DESCRIPTION
Examples of this updated scheme:

- http://localhost:5173/forecasts/flusight
- http://localhost:5173/forecasts/flusight/peak/CO
- http://localhost:5173/forecasts/flusight/detailed/DC
- http://localhost:5173/forecasts/flu-metrocast/GA
- http://localhost:5173/forecasts/flu-metrocast/GA_columbus
- http://localhost:5173/forecasts/rsv/IN

- http://localhost:5173/surveillance/nhsn/NC
- http://localhost:5173/surveillance/nssp/NC_All
- http://localhost:5173/surveillance/nssp/NC_235

Unified on: `http://respilens.com/<date type>/<pathogen>/<sub-view>/<state abbrev>_<sub_loc_name>`
but we could:
- pivot away from the state abbreviation (i.e., use `north-carolina` instead of `NC`) 
- not distinguish between surveillance vs. forecast data
- remove the sub view layer i.e.: 
    - http://localhost:5173/forecasts/flu/peak/CO would become http://localhost:5173/forecasts/flu-peak/CO
    - http://localhost:5173/forecasts/flu/metrocast/GA would become http://localhost:5173/forecasts/flu-metrocast/GA
    - etc.

Open to tweaks from @jcblemai !