### PR TITLE
Small ux improvements

### DIFF
--- a/app/src/components/FluPeak.jsx
+++ b/app/src/components/FluPeak.jsx
@@ -5,7 +5,15 @@ import ModelSelector from "./ModelSelector";
 import { getModelColor } from "../config/datasets";
 import { CHART_CONSTANTS } from "../constants/chart";
 import { getDataPath } from "../utils/paths";
-import { buildSqrtTicks, getYRangeFromTraces } from "../utils/scaleUtils";
+import {
+  buildLog2Ticks,
+  buildSqrtTicks,
+  getScaleTitleSuffix,
+  getYRangeFromTraces,
+  isPlotlyLogScale,
+  normalizeChartScale,
+  transformValueForScale,
+} from "../utils/scaleUtils";
 import { buildPlotDownloadName } from "../utils/plotDownloadName";
 import { extendStableModelOrder } from "../utils/modelColorUtils";
 
@@ -49,6 +57,7 @@ const FluPeak = ({
   const showMedian = intervalVisibility?.median ?? true;
   const show50 = intervalVisibility?.ci50 ?? true;
   const show95 = intervalVisibility?.ci95 ?? true;
+  const normalizedChartScale = normalizeChartScale(chartScale);
   const stableModelOrderRef = useRef([]);
   const stableModelOrder = useMemo(() => {
     const nextOrder = extendStableModelOrder(
@@ -458,14 +467,16 @@ const FluPeak = ({
 
     const rawRange = getYRangeFromTraces(traces);
 
-    if (chartScale !== "sqrt") {
+    if (normalizedChartScale !== "sqrt" && normalizedChartScale !== "log2") {
       return { plotData: traces, rawYRange: rawRange };
     }
 
     const scaledTraces = traces.map((trace) => {
       if (!Array.isArray(trace.y)) return trace;
       const originalY = trace.y;
-      const scaledY = originalY.map((value) => Math.sqrt(Math.max(0, value)));
+      const scaledY = originalY.map((value) =>
+        transformValueForScale(value, normalizedChartScale),
+      );
       const nextTrace = { ...trace, y: scaledY };
 
       if (trace.hovertemplate && trace.hovertemplate.includes("%{y}")) {
@@ -497,17 +508,25 @@ const FluPeak = ({
     showMedian,
     show50,
     show95,
-    chartScale,
+    normalizedChartScale,
     stableModelOrder,
   ]);
 
   const sqrtTicks = useMemo(() => {
-    if (chartScale !== "sqrt") return null;
+    if (normalizedChartScale !== "sqrt") return null;
     return buildSqrtTicks({
       rawRange: rawYRange,
       formatValue: (value) => Number(value).toLocaleString(),
     });
-  }, [chartScale, rawYRange]);
+  }, [normalizedChartScale, rawYRange]);
+
+  const log2Ticks = useMemo(() => {
+    if (normalizedChartScale !== "log2") return null;
+    return buildLog2Ticks({
+      rawRange: rawYRange,
+      formatValue: (value) => Number(value).toLocaleString(),
+    });
+  }, [normalizedChartScale, rawYRange]);
 
   const layout = useMemo(
     () => ({
@@ -549,17 +568,27 @@ const FluPeak = ({
       yaxis: {
         title: (() => {
           const baseTitle = "Flu Hospitalizations";
-          if (chartScale === "log") return `${baseTitle} (log)`;
-          if (chartScale === "sqrt") return `${baseTitle} (sqrt)`;
-          return baseTitle;
+          return `${baseTitle}${getScaleTitleSuffix(normalizedChartScale)}`;
         })(),
         rangemode: "tozero",
-        type: chartScale === "log" ? "log" : "linear",
-        tickmode: chartScale === "sqrt" && sqrtTicks ? "array" : undefined,
+        type: isPlotlyLogScale(normalizedChartScale) ? "log" : "linear",
+        tickmode:
+          (normalizedChartScale === "sqrt" && sqrtTicks) ||
+          (normalizedChartScale === "log2" && log2Ticks)
+            ? "array"
+            : undefined,
         tickvals:
-          chartScale === "sqrt" && sqrtTicks ? sqrtTicks.tickvals : undefined,
+          normalizedChartScale === "sqrt" && sqrtTicks
+            ? sqrtTicks.tickvals
+            : normalizedChartScale === "log2" && log2Ticks
+              ? log2Ticks.tickvals
+              : undefined,
         ticktext:
-          chartScale === "sqrt" && sqrtTicks ? sqrtTicks.ticktext : undefined,
+          normalizedChartScale === "sqrt" && sqrtTicks
+            ? sqrtTicks.ticktext
+            : normalizedChartScale === "log2" && log2Ticks
+              ? log2Ticks.ticktext
+              : undefined,
       },
 
       // dynamic gray shading section
@@ -597,7 +626,15 @@ const FluPeak = ({
         ];
       }),
     }),
-    [colorScheme, windowSize, selectedDates, chartScale, sqrtTicks, showLegend],
+    [
+      colorScheme,
+      windowSize,
+      selectedDates,
+      normalizedChartScale,
+      sqrtTicks,
+      log2Ticks,
+      showLegend,
+    ],
   );
 
   const config = useMemo(

--- a/app/src/components/ForecastPlotView.jsx
+++ b/app/src/components/ForecastPlotView.jsx
@@ -123,7 +123,7 @@ const ForecastPlotView = ({
     valueSuffix: "",
     modelLineWidth: 2,
     modelMarkerSize: 6,
-    groundTruthLineWidth: 2,
+    groundTruthLineWidth: 1.5,
     groundTruthMarkerSize: 4,
     showLegendForFirstDate: showLegend,
     fillMissingQuantiles: false,

--- a/app/src/components/ForecastPlotView.jsx
+++ b/app/src/components/ForecastPlotView.jsx
@@ -7,7 +7,14 @@ import TitleRow from "./TitleRow";
 import { CHART_CONSTANTS } from "../constants/chart";
 import { targetDisplayNameMap, targetYAxisLabelMap } from "../utils/mapUtils";
 import useQuantileForecastTraces from "../hooks/useQuantileForecastTraces";
-import { buildSqrtTicks } from "../utils/scaleUtils";
+import {
+  buildLog2Ticks,
+  buildSqrtTicks,
+  getScaleTitleSuffix,
+  isPlotlyLogScale,
+  normalizeChartScale,
+  transformValueForScale,
+} from "../utils/scaleUtils";
 import { useView } from "../hooks/useView";
 import { getDatasetTitleFromView } from "../utils/datasetUtils";
 import { buildPlotDownloadName } from "../utils/plotDownloadName";
@@ -66,11 +73,14 @@ const ForecastPlotView = ({
   const show95 = intervalVisibility?.ci95 ?? true;
   const baselineModelName =
     getOfficialModels(FORECAST_DATASET_KEYS_BY_VIEW[viewType]).baseline || null;
+  const normalizedChartScale = normalizeChartScale(chartScale);
 
-  const sqrtTransform = useMemo(() => {
-    if (chartScale !== "sqrt") return null;
-    return (value) => Math.sqrt(Math.max(0, value));
-  }, [chartScale]);
+  const manualScaleTransform = useMemo(() => {
+    if (normalizedChartScale !== "sqrt" && normalizedChartScale !== "log2") {
+      return null;
+    }
+    return (value) => transformValueForScale(value, normalizedChartScale);
+  }, [normalizedChartScale]);
 
   const calculateYRange = useCallback(
     (chartData, xRange) => {
@@ -130,9 +140,9 @@ const ForecastPlotView = ({
     showMedian,
     show50,
     show95,
-    transformY: sqrtTransform,
+    transformY: manualScaleTransform,
     baselineModelName,
-    groundTruthHoverFormatter: sqrtTransform
+    groundTruthHoverFormatter: manualScaleTransform
       ? (value) =>
           groundTruthValueFormat.includes(":.2f")
             ? Number(value).toFixed(2)
@@ -217,9 +227,14 @@ const ForecastPlotView = ({
   );
 
   const sqrtTicks = useMemo(() => {
-    if (chartScale !== "sqrt") return null;
+    if (normalizedChartScale !== "sqrt") return null;
     return buildSqrtTicks({ rawRange: rawYRange });
-  }, [chartScale, rawYRange]);
+  }, [normalizedChartScale, rawYRange]);
+
+  const log2Ticks = useMemo(() => {
+    if (normalizedChartScale !== "log2") return null;
+    return buildLog2Ticks({ rawRange: rawYRange });
+  }, [normalizedChartScale, rawYRange]);
 
   const layout = useMemo(() => {
     const baseLayout = {
@@ -274,18 +289,30 @@ const ForecastPlotView = ({
             longName ||
             resolvedDisplayTarget ||
             "Value";
-          if (chartScale === "log") return `${baseTitle} (log)`;
-          if (chartScale === "sqrt") return `${baseTitle} (sqrt)`;
-          return baseTitle;
+          return `${baseTitle}${getScaleTitleSuffix(normalizedChartScale)}`;
         })(),
-        range: chartScale === "log" ? undefined : yAxisRange,
-        autorange: chartScale === "log" ? true : yAxisRange === null,
-        type: chartScale === "log" ? "log" : "linear",
-        tickmode: chartScale === "sqrt" && sqrtTicks ? "array" : undefined,
+        range: isPlotlyLogScale(normalizedChartScale) ? undefined : yAxisRange,
+        autorange: isPlotlyLogScale(normalizedChartScale)
+          ? true
+          : yAxisRange === null,
+        type: isPlotlyLogScale(normalizedChartScale) ? "log" : "linear",
+        tickmode:
+          (normalizedChartScale === "sqrt" && sqrtTicks) ||
+          (normalizedChartScale === "log2" && log2Ticks)
+            ? "array"
+            : undefined,
         tickvals:
-          chartScale === "sqrt" && sqrtTicks ? sqrtTicks.tickvals : undefined,
+          normalizedChartScale === "sqrt" && sqrtTicks
+            ? sqrtTicks.tickvals
+            : normalizedChartScale === "log2" && log2Ticks
+              ? log2Ticks.tickvals
+              : undefined,
         ticktext:
-          chartScale === "sqrt" && sqrtTicks ? sqrtTicks.ticktext : undefined,
+          normalizedChartScale === "sqrt" && sqrtTicks
+            ? sqrtTicks.ticktext
+            : normalizedChartScale === "log2" && log2Ticks
+              ? log2Ticks.ticktext
+              : undefined,
       },
       shapes: selectedDates.map((date) => {
         const shiftedDate = shiftDateStringByDays(date, -3);
@@ -319,8 +346,9 @@ const ForecastPlotView = ({
     xAxisRange,
     getDefaultRange,
     layoutOverrides,
-    chartScale,
+    normalizedChartScale,
     sqrtTicks,
+    log2Ticks,
     showLegend,
   ]);
 

--- a/app/src/components/controls/ForecastChartControls.jsx
+++ b/app/src/components/controls/ForecastChartControls.jsx
@@ -15,7 +15,8 @@ const INTERVAL_OPTIONS = [
 
 const SCALE_OPTIONS = [
   { value: "linear", label: "Linear" },
-  { value: "log", label: "Log" },
+  { value: "log10", label: "Log10" },
+  { value: "log2", label: "Log2" },
   { value: "sqrt", label: "Sqrt" },
 ];
 

--- a/app/src/components/myplots/MiniPlot.jsx
+++ b/app/src/components/myplots/MiniPlot.jsx
@@ -14,7 +14,14 @@ import Plot from "react-plotly.js";
 import useQuantileForecastTraces from "../../hooks/useQuantileForecastTraces";
 import { getModelColor } from "../../config/datasets";
 import { nhsnSlugToNameMap, targetDisplayNameMap } from "../../utils/mapUtils";
-import { buildSqrtTicks, getYRangeFromTraces } from "../../utils/scaleUtils";
+import {
+  buildLog2Ticks,
+  buildSqrtTicks,
+  getYRangeFromTraces,
+  isPlotlyLogScale,
+  normalizeChartScale,
+  transformValueForScale,
+} from "../../utils/scaleUtils";
 
 const NSSP_COLUMN_LABELS = {
   percent_visits_covid: "COVID-19",
@@ -49,6 +56,7 @@ const MiniPlot = ({ plot, onMetadataLoad, plotHeight = 210 }) => {
   const isNSSP = plot.viewType === "nsspall";
   const isFluPeak = plot.viewType === "flu_peak";
   const isSeriesView = isNHSN || isNSSP;
+  const normalizedScale = normalizeChartScale(plot.settings.scale);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -83,23 +91,23 @@ const MiniPlot = ({ plot, onMetadataLoad, plotHeight = 210 }) => {
     showLegendForFirstDate: false,
     modelLineWidth: 1.5,
     modelMarkerSize: 4,
+    transformY:
+      normalizedScale === "sqrt" || normalizedScale === "log2"
+        ? (value) => transformValueForScale(value, normalizedScale)
+        : null,
   });
 
   const nhsnTraces = useMemo(() => {
     if (!isNHSN || !data?.series) return [];
 
     const dateAxis = data.series.dates;
-    const applySqrt = plot.settings.scale === "sqrt";
-
     return (plot.settings.columns || [])
       .map((slug) => {
         const longformName = nhsnSlugToNameMap[slug] || slug;
         const rawY = data.series[longformName] || [];
-        const yValues = applySqrt
-          ? rawY.map((value) =>
-              value !== null ? Math.sqrt(Math.max(0, value)) : value,
-            )
-          : rawY;
+        const yValues = rawY.map((value) =>
+          transformValueForScale(value, normalizedScale),
+        );
 
         return {
           x: dateAxis,
@@ -114,22 +122,18 @@ const MiniPlot = ({ plot, onMetadataLoad, plotHeight = 210 }) => {
         };
       })
       .filter((trace) => trace.y.length > 0);
-  }, [isNHSN, data, plot.settings]);
+  }, [isNHSN, data, plot.settings, normalizedScale]);
 
   const nsspTraces = useMemo(() => {
     if (!isNSSP || !data?.series) return [];
 
     const dateAxis = data.series.dates || [];
-    const applySqrt = plot.settings.scale === "sqrt";
-
     return (plot.settings.columns || [])
       .map((column) => {
         const rawY = data.series[column] || [];
-        const yValues = applySqrt
-          ? rawY.map((value) =>
-              value !== null ? Math.sqrt(Math.max(0, value)) : value,
-            )
-          : rawY;
+        const yValues = rawY.map((value) =>
+          transformValueForScale(value, normalizedScale),
+        );
 
         return {
           x: dateAxis,
@@ -148,7 +152,7 @@ const MiniPlot = ({ plot, onMetadataLoad, plotHeight = 210 }) => {
         };
       })
       .filter((trace) => trace.y.length > 0);
-  }, [isNSSP, data, plot.settings]);
+  }, [isNSSP, data, plot.settings, normalizedScale]);
 
   const fluPeakTraces = useMemo(() => {
     if (!isFluPeak || !data) return [];
@@ -161,10 +165,9 @@ const MiniPlot = ({ plot, onMetadataLoad, plotHeight = 210 }) => {
     const showMedian = plot.settings.intervals?.includes("median") ?? true;
     const show50 = plot.settings.intervals?.includes("ci50") ?? true;
     const show95 = plot.settings.intervals?.includes("ci95") ?? true;
-    const applySqrt = plot.settings.scale === "sqrt";
     const transformY = (value) => {
       if (value === null || value === undefined) return value;
-      return applySqrt ? Math.sqrt(Math.max(0, value)) : value;
+      return transformValueForScale(value, normalizedScale);
     };
 
     if (groundTruth?.["wk inc flu hosp"] && groundTruth?.dates) {
@@ -305,7 +308,7 @@ const MiniPlot = ({ plot, onMetadataLoad, plotHeight = 210 }) => {
     });
 
     return traces;
-  }, [isFluPeak, data, plot.settings]);
+  }, [isFluPeak, data, plot.settings, normalizedScale]);
 
   let finalTraces = forecastTraces;
   if (isNHSN) {
@@ -364,8 +367,15 @@ const MiniPlot = ({ plot, onMetadataLoad, plotHeight = 210 }) => {
       }
     }
 
+    const usesPercentSuffix =
+      isNSSP ||
+      plot.settings.target?.includes("%") ||
+      plot.settings.target?.includes("pct") ||
+      plot.settings.target?.includes("Percent") ||
+      plot.settings.target?.includes("percent");
+
     const sqrtTicks =
-      plot.settings.scale === "sqrt" && yRange
+      normalizedScale === "sqrt" && yRange
         ? buildSqrtTicks({
             rawRange: [0, yRange[1] ** 2],
             tickCount: 4,
@@ -376,12 +386,17 @@ const MiniPlot = ({ plot, onMetadataLoad, plotHeight = 210 }) => {
           })
         : null;
 
-    const usesPercentSuffix =
-      isNSSP ||
-      plot.settings.target?.includes("%") ||
-      plot.settings.target?.includes("pct") ||
-      plot.settings.target?.includes("Percent") ||
-      plot.settings.target?.includes("percent");
+    const log2Ticks =
+      normalizedScale === "log2" && yRange
+        ? buildLog2Ticks({
+            rawRange: [1, 2 ** yRange[1]],
+            maxTickCount: 4,
+            formatValue: (value) =>
+              value.toLocaleString(undefined, {
+                maximumFractionDigits: usesPercentSuffix ? 2 : 0,
+              }),
+          })
+        : null;
 
     return {
       autosize: true,
@@ -404,12 +419,17 @@ const MiniPlot = ({ plot, onMetadataLoad, plotHeight = 210 }) => {
         gridcolor: colorScheme === "dark" ? "#333" : "#eee",
         fixedrange: true,
         tickfont: { size: 8 },
-        type: plot.settings.scale === "log" ? "log" : "linear",
-        range: plot.settings.scale === "log" ? undefined : yRange,
+        type: isPlotlyLogScale(normalizedScale) ? "log" : "linear",
+        range: isPlotlyLogScale(normalizedScale) ? undefined : yRange,
         nticks: 5,
-        ticksuffix: usesPercentSuffix ? "%" : "",
-        tickvals: sqrtTicks?.tickvals,
-        ticktext: sqrtTicks?.ticktext,
+        ticksuffix:
+          normalizedScale === "sqrt" || normalizedScale === "log2"
+            ? undefined
+            : usesPercentSuffix
+              ? "%"
+              : "",
+        tickvals: sqrtTicks?.tickvals ?? log2Ticks?.tickvals,
+        ticktext: sqrtTicks?.ticktext ?? log2Ticks?.ticktext,
       },
       shapes:
         !isNHSN && !isNSSP && !isFluPeak
@@ -427,6 +447,7 @@ const MiniPlot = ({ plot, onMetadataLoad, plotHeight = 210 }) => {
   }, [
     colorScheme,
     plot.settings,
+    normalizedScale,
     isNHSN,
     isNSSP,
     isFluPeak,
@@ -485,7 +506,7 @@ const MiniPlot = ({ plot, onMetadataLoad, plotHeight = 210 }) => {
             SCALE:
           </Text>
           <Badge size="xs" variant="outline" color="blue.3">
-            {plot.settings.scale?.toUpperCase()}
+            {normalizedScale.toUpperCase()}
           </Badge>
         </Group>
 
@@ -512,7 +533,7 @@ const MiniPlot = ({ plot, onMetadataLoad, plotHeight = 210 }) => {
         )}
       </Stack>
     );
-  }, [plot.settings, isNHSN, isNSSP]);
+  }, [plot.settings, isNHSN, isNSSP, normalizedScale]);
 
   if (loading) {
     return (

--- a/app/src/components/myrespi/MyRespiLensDashboard.jsx
+++ b/app/src/components/myrespi/MyRespiLensDashboard.jsx
@@ -43,7 +43,14 @@ import useQuantileForecastTraces from "../../hooks/useQuantileForecastTraces";
 import { MODEL_COLORS } from "../../config/datasets";
 import { CHART_CONSTANTS } from "../../constants/chart";
 import { extendStableModelOrder } from "../../utils/modelColorUtils";
-import { buildSqrtTicks } from "../../utils/scaleUtils";
+import {
+  buildLog2Ticks,
+  buildSqrtTicks,
+  getScaleTitleSuffix,
+  isPlotlyLogScale,
+  normalizeChartScale,
+  transformValueForScale,
+} from "../../utils/scaleUtils";
 
 const HUB_OPTIONS = [
   {
@@ -1197,6 +1204,7 @@ const MyRespiVisualizationPanel = ({
   const [selectedDates, setSelectedDates] = useState([]);
   const [activeDate, setActiveDate] = useState(null);
   const [chartScale, setChartScale] = useState("linear");
+  const normalizedChartScale = normalizeChartScale(chartScale);
   const [intervalVisibility, setIntervalVisibility] = useState({});
   const [submittedIntervalVisibility, setSubmittedIntervalVisibility] =
     useState({
@@ -1566,10 +1574,12 @@ const MyRespiVisualizationPanel = ({
     return activeModelSet;
   }, [filteredComparisonLocationData, selectedTarget, selectedDates]);
 
-  const sqrtTransform = useMemo(() => {
-    if (chartScale !== "sqrt") return null;
-    return (value) => Math.sqrt(Math.max(0, value));
-  }, [chartScale]);
+  const manualScaleTransform = useMemo(() => {
+    if (normalizedChartScale !== "sqrt" && normalizedChartScale !== "log2") {
+      return null;
+    }
+    return (value) => transformValueForScale(value, normalizedChartScale);
+  }, [normalizedChartScale]);
 
   const { traces, rawYRange } = useQuantileForecastTraces({
     groundTruth: locationData?.ground_truth,
@@ -1582,7 +1592,7 @@ const MyRespiVisualizationPanel = ({
     fillMissingQuantiles: false,
     intervalDefinitions,
     intervalVisibility,
-    transformY: sqrtTransform,
+    transformY: manualScaleTransform,
   });
   const {
     traces: submittedModelTraceBundle,
@@ -1601,7 +1611,7 @@ const MyRespiVisualizationPanel = ({
     modelColorFn: submittedModelColorFn,
     modelOrder: stableSubmittedModelOrder,
     modelHoverBuilder: buildComparisonHoverText,
-    transformY: sqrtTransform,
+    transformY: manualScaleTransform,
   });
   const submittedModelTraces = useMemo(
     () => submittedModelTraceBundle.slice(1),
@@ -1675,7 +1685,7 @@ const MyRespiVisualizationPanel = ({
   }, [selectedLocationFile, selectedTarget]);
 
   useEffect(() => {
-    if (chartScale === "log") {
+    if (isPlotlyLogScale(normalizedChartScale)) {
       setYAxisRange(null);
       return;
     }
@@ -1685,12 +1695,23 @@ const MyRespiVisualizationPanel = ({
     } else {
       setYAxisRange(null);
     }
-  }, [allTraces, xAxisRange, defaultRange, calculateYRange, chartScale]);
+  }, [
+    allTraces,
+    xAxisRange,
+    defaultRange,
+    calculateYRange,
+    normalizedChartScale,
+  ]);
 
   const sqrtTicks = useMemo(() => {
-    if (chartScale !== "sqrt") return null;
+    if (normalizedChartScale !== "sqrt") return null;
     return buildSqrtTicks({ rawRange: combinedRawYRange });
-  }, [chartScale, combinedRawYRange]);
+  }, [normalizedChartScale, combinedRawYRange]);
+
+  const log2Ticks = useMemo(() => {
+    if (normalizedChartScale !== "log2") return null;
+    return buildLog2Ticks({ rawRange: combinedRawYRange });
+  }, [normalizedChartScale, combinedRawYRange]);
 
   const handlePlotUpdate = useCallback((figure) => {
     if (isResettingRef.current) {
@@ -1733,15 +1754,29 @@ const MyRespiVisualizationPanel = ({
         range: xAxisRange || defaultRange,
       },
       yaxis: {
-        title: selectedTarget || "Value",
-        range: chartScale === "log" ? undefined : yAxisRange,
-        autorange: chartScale === "log" ? true : yAxisRange === null,
-        type: chartScale === "log" ? "log" : "linear",
-        tickmode: chartScale === "sqrt" && sqrtTicks ? "array" : undefined,
+        title: `${selectedTarget || "Value"}${getScaleTitleSuffix(normalizedChartScale)}`,
+        range: isPlotlyLogScale(normalizedChartScale) ? undefined : yAxisRange,
+        autorange: isPlotlyLogScale(normalizedChartScale)
+          ? true
+          : yAxisRange === null,
+        type: isPlotlyLogScale(normalizedChartScale) ? "log" : "linear",
+        tickmode:
+          (normalizedChartScale === "sqrt" && sqrtTicks) ||
+          (normalizedChartScale === "log2" && log2Ticks)
+            ? "array"
+            : undefined,
         tickvals:
-          chartScale === "sqrt" && sqrtTicks ? sqrtTicks.tickvals : undefined,
+          normalizedChartScale === "sqrt" && sqrtTicks
+            ? sqrtTicks.tickvals
+            : normalizedChartScale === "log2" && log2Ticks
+              ? log2Ticks.tickvals
+              : undefined,
         ticktext:
-          chartScale === "sqrt" && sqrtTicks ? sqrtTicks.ticktext : undefined,
+          normalizedChartScale === "sqrt" && sqrtTicks
+            ? sqrtTicks.ticktext
+            : normalizedChartScale === "log2" && log2Ticks
+              ? log2Ticks.ticktext
+              : undefined,
       },
       shapes: selectedDates.map((date) => {
         const shiftedDate = shiftDateStringByDays(date, -3);
@@ -1764,9 +1799,10 @@ const MyRespiVisualizationPanel = ({
       xAxisRange,
       defaultRange,
       selectedTarget,
-      chartScale,
+      normalizedChartScale,
       yAxisRange,
       sqrtTicks,
+      log2Ticks,
     ],
   );
 
@@ -1789,7 +1825,7 @@ const MyRespiVisualizationPanel = ({
               false,
             );
             const nextYRange =
-              chartScale === "log" || !range
+              isPlotlyLogScale(normalizedChartScale) || !range
                 ? null
                 : calculateYRange(allTraces, range);
             isResettingRef.current = true;
@@ -1798,13 +1834,20 @@ const MyRespiVisualizationPanel = ({
             Plotly.relayout(gd, {
               "xaxis.range": range,
               "yaxis.range": nextYRange,
-              "yaxis.autorange": chartScale === "log" || nextYRange === null,
+              "yaxis.autorange":
+                isPlotlyLogScale(normalizedChartScale) || nextYRange === null,
             });
           },
         },
       ],
     }),
-    [allTraces, locationData, selectedDates, chartScale, calculateYRange],
+    [
+      allTraces,
+      locationData,
+      selectedDates,
+      normalizedChartScale,
+      calculateYRange,
+    ],
   );
 
   if ((!isMetrocast && !locationOptions.length) || !locationData) {

--- a/app/src/components/views/MetroCastView.jsx
+++ b/app/src/components/views/MetroCastView.jsx
@@ -108,7 +108,7 @@ const MetroPlotCard = ({
     formatValue: (value) => value.toFixed(2),
     modelLineWidth: isSmall ? 1 : 2,
     modelMarkerSize: isSmall ? 3 : 6,
-    groundTruthLineWidth: isSmall ? 1 : 2,
+    groundTruthLineWidth: 1.5,
     groundTruthMarkerSize: isSmall ? 2 : 4,
     showLegendForFirstDate: showLegend && !isSmall,
     fillMissingQuantiles: true,

--- a/app/src/components/views/MetroCastView.jsx
+++ b/app/src/components/views/MetroCastView.jsx
@@ -21,7 +21,14 @@ import {
 } from "../../utils/mapUtils";
 import { getDataPath } from "../../utils/paths";
 import useQuantileForecastTraces from "../../hooks/useQuantileForecastTraces";
-import { buildSqrtTicks } from "../../utils/scaleUtils";
+import {
+  buildLog2Ticks,
+  buildSqrtTicks,
+  getScaleTitleSuffix,
+  isPlotlyLogScale,
+  normalizeChartScale,
+  transformValueForScale,
+} from "../../utils/scaleUtils";
 import { getDatasetTitleFromView } from "../../utils/datasetUtils";
 
 const METRO_STATE_MAP = {
@@ -90,11 +97,14 @@ const MetroPlotCard = ({
   const showMedian = intervalVisibility?.median ?? true;
   const show50 = intervalVisibility?.ci50 ?? true;
   const show95 = intervalVisibility?.ci95 ?? true;
+  const normalizedChartScale = normalizeChartScale(chartScale);
 
-  const sqrtTransform = useMemo(() => {
-    if (chartScale !== "sqrt") return null;
-    return (value) => Math.sqrt(Math.max(0, value));
-  }, [chartScale]);
+  const manualScaleTransform = useMemo(() => {
+    if (normalizedChartScale !== "sqrt" && normalizedChartScale !== "log2") {
+      return null;
+    }
+    return (value) => transformValueForScale(value, normalizedChartScale);
+  }, [normalizedChartScale]);
 
   const { traces: projectionsData, rawYRange } = useQuantileForecastTraces({
     groundTruth,
@@ -115,8 +125,8 @@ const MetroPlotCard = ({
     showMedian,
     show50,
     show95,
-    transformY: sqrtTransform,
-    groundTruthHoverFormatter: sqrtTransform
+    transformY: manualScaleTransform,
+    groundTruthHoverFormatter: manualScaleTransform
       ? (value) => Number(value).toFixed(2)
       : null,
   });
@@ -129,12 +139,20 @@ const MetroPlotCard = ({
   }, [projectionsData, xAxisRange, defRange, calculateYRange]);
 
   const sqrtTicks = useMemo(() => {
-    if (chartScale !== "sqrt") return null;
+    if (normalizedChartScale !== "sqrt") return null;
     return buildSqrtTicks({
       rawRange: rawYRange,
       formatValue: (value) => `${value.toFixed(2)}%`,
     });
-  }, [chartScale, rawYRange]);
+  }, [normalizedChartScale, rawYRange]);
+
+  const log2Ticks = useMemo(() => {
+    if (normalizedChartScale !== "log2") return null;
+    return buildLog2Ticks({
+      rawRange: rawYRange,
+      formatValue: (value) => `${value.toFixed(2)}%`,
+    });
+  }, [normalizedChartScale, rawYRange]);
 
   const hasForecasts = projectionsData.length > 1;
 
@@ -211,9 +229,7 @@ const MetroPlotCard = ({
                       longName ||
                       selectedTarget ||
                       "Value";
-                    if (chartScale === "log") return `${baseTitle} (log)`;
-                    if (chartScale === "sqrt") return `${baseTitle} (sqrt)`;
-                    return baseTitle;
+                    return `${baseTitle}${getScaleTitleSuffix(normalizedChartScale)}`;
                   })(),
                   font: {
                     color: colorScheme === "dark" ? "#c1c2c5" : "#000000",
@@ -221,24 +237,42 @@ const MetroPlotCard = ({
                   },
                 }
               : undefined,
-            range: chartScale === "log" ? undefined : yAxisRange,
-            autorange: chartScale === "log" ? true : yAxisRange === null,
-            type: chartScale === "log" ? "log" : "linear",
+            range: isPlotlyLogScale(normalizedChartScale)
+              ? undefined
+              : yAxisRange,
+            autorange: isPlotlyLogScale(normalizedChartScale)
+              ? true
+              : yAxisRange === null,
+            type: isPlotlyLogScale(normalizedChartScale) ? "log" : "linear",
             tickfont: {
               size: 9,
               color: colorScheme === "dark" ? "#c1c2c5" : "#000000",
             },
-            tickformat: chartScale === "sqrt" ? undefined : ".2f",
-            ticksuffix: chartScale === "sqrt" ? undefined : "%",
-            tickmode: chartScale === "sqrt" && sqrtTicks ? "array" : undefined,
+            tickformat:
+              normalizedChartScale === "sqrt" || normalizedChartScale === "log2"
+                ? undefined
+                : ".2f",
+            ticksuffix:
+              normalizedChartScale === "sqrt" || normalizedChartScale === "log2"
+                ? undefined
+                : "%",
+            tickmode:
+              (normalizedChartScale === "sqrt" && sqrtTicks) ||
+              (normalizedChartScale === "log2" && log2Ticks)
+                ? "array"
+                : undefined,
             tickvals:
-              chartScale === "sqrt" && sqrtTicks
+              normalizedChartScale === "sqrt" && sqrtTicks
                 ? sqrtTicks.tickvals
-                : undefined,
+                : normalizedChartScale === "log2" && log2Ticks
+                  ? log2Ticks.tickvals
+                  : undefined,
             ticktext:
-              chartScale === "sqrt" && sqrtTicks
+              normalizedChartScale === "sqrt" && sqrtTicks
                 ? sqrtTicks.ticktext
-                : undefined,
+                : normalizedChartScale === "log2" && log2Ticks
+                  ? log2Ticks.ticktext
+                  : undefined,
           },
           hovermode: isSmall ? false : "closest",
           hoverlabel: {

--- a/app/src/components/views/NHSNView.jsx
+++ b/app/src/components/views/NHSNView.jsx
@@ -14,7 +14,15 @@ import { getDataPath } from "../../utils/paths";
 import NHSNColumnSelector from "../NHSNColumnSelector";
 import TitleRow from "../TitleRow";
 import { MODEL_COLORS } from "../../config/datasets";
-import { buildSqrtTicks, getYRangeFromTraces } from "../../utils/scaleUtils";
+import {
+  buildLog2Ticks,
+  buildSqrtTicks,
+  getScaleTitleSuffix,
+  getYRangeFromTraces,
+  isPlotlyLogScale,
+  normalizeChartScale,
+  transformValueForScale,
+} from "../../utils/scaleUtils";
 import { useView } from "../../hooks/useView";
 import { getDatasetTitleFromView } from "../../utils/datasetUtils";
 import { buildPlotDownloadName } from "../../utils/plotDownloadName";
@@ -67,6 +75,7 @@ const NHSNView = ({ location }) => {
   const [error, setError] = useState(null);
   const { colorScheme } = useMantineColorScheme();
   const { viewType, chartScale, showLegend } = useView();
+  const normalizedChartScale = normalizeChartScale(chartScale);
   const stateName = data?.metadata?.location_name;
   const hubName = getDatasetTitleFromView(viewType) || metadata?.dataset;
 
@@ -95,12 +104,10 @@ const NHSNView = ({ location }) => {
       return rawValues.map((val) => {
         if (val === null || val === undefined) return val;
         const transformed = val;
-        return chartScale === "sqrt"
-          ? Math.sqrt(Math.max(0, transformed))
-          : transformed;
+        return transformValueForScale(transformed, normalizedChartScale);
       });
     },
-    [chartScale],
+    [normalizedChartScale],
   );
 
   useEffect(() => {
@@ -433,9 +440,14 @@ const NHSNView = ({ location }) => {
   const rawYRange = useMemo(() => getYRangeFromTraces(rawTraces), [rawTraces]);
 
   const sqrtTicks = useMemo(() => {
-    if (chartScale !== "sqrt") return null;
+    if (normalizedChartScale !== "sqrt") return null;
     return buildSqrtTicks({ rawRange: rawYRange });
-  }, [chartScale, rawYRange]);
+  }, [normalizedChartScale, rawYRange]);
+
+  const log2Ticks = useMemo(() => {
+    if (normalizedChartScale !== "log2") return null;
+    return buildLog2Ticks({ rawRange: rawYRange });
+  }, [normalizedChartScale, rawYRange]);
 
   const traces = useMemo(() => {
     if (!data) return [];
@@ -501,18 +513,29 @@ const NHSNView = ({ location }) => {
         range: xAxisRange || defaultRange,
       },
       yaxis: {
-        title: nhsnYAxisLabelMap[selectedTarget] || "Value",
-        range: chartScale === "log" ? undefined : yAxisRange,
-        autorange:
-          chartScale === "log"
-            ? true
-            : yAxisRange === null || selectedColumns.length === 0,
-        type: chartScale === "log" ? "log" : "linear",
-        tickmode: chartScale === "sqrt" && sqrtTicks ? "array" : undefined,
+        title: `${nhsnYAxisLabelMap[selectedTarget] || "Value"}${getScaleTitleSuffix(normalizedChartScale)}`,
+        range: isPlotlyLogScale(normalizedChartScale) ? undefined : yAxisRange,
+        autorange: isPlotlyLogScale(normalizedChartScale)
+          ? true
+          : yAxisRange === null || selectedColumns.length === 0,
+        type: isPlotlyLogScale(normalizedChartScale) ? "log" : "linear",
+        tickmode:
+          (normalizedChartScale === "sqrt" && sqrtTicks) ||
+          (normalizedChartScale === "log2" && log2Ticks)
+            ? "array"
+            : undefined,
         tickvals:
-          chartScale === "sqrt" && sqrtTicks ? sqrtTicks.tickvals : undefined,
+          normalizedChartScale === "sqrt" && sqrtTicks
+            ? sqrtTicks.tickvals
+            : normalizedChartScale === "log2" && log2Ticks
+              ? log2Ticks.tickvals
+              : undefined,
         ticktext:
-          chartScale === "sqrt" && sqrtTicks ? sqrtTicks.ticktext : undefined,
+          normalizedChartScale === "sqrt" && sqrtTicks
+            ? sqrtTicks.ticktext
+            : normalizedChartScale === "log2" && log2Ticks
+              ? log2Ticks.ticktext
+              : undefined,
       },
       showlegend: showLegend ?? selectedColumns.length < 15,
       legend: {
@@ -552,12 +575,13 @@ const NHSNView = ({ location }) => {
       defaultRange,
       xAxisRange,
       yAxisRange,
-      chartScale,
+      normalizedChartScale,
       showLegend,
       selectedTarget,
       selectedColumns.length,
       plotRevision,
       sqrtTicks,
+      log2Ticks,
     ],
   );
 

--- a/app/src/components/views/NSSPView.jsx
+++ b/app/src/components/views/NSSPView.jsx
@@ -21,7 +21,15 @@ import TitleRow from "../TitleRow";
 import { MODEL_COLORS } from "../../config/datasets";
 import { useView } from "../../hooks/useView";
 import { buildPlotDownloadName } from "../../utils/plotDownloadName";
-import { buildSqrtTicks, getYRangeFromTraces } from "../../utils/scaleUtils";
+import {
+  buildLog2Ticks,
+  buildSqrtTicks,
+  getScaleTitleSuffix,
+  getYRangeFromTraces,
+  isPlotlyLogScale,
+  normalizeChartScale,
+  transformValueForScale,
+} from "../../utils/scaleUtils";
 import {
   NSSP_MAP_COLORS as MAP_COLORS,
   NSSP_MAP_HEIGHTS,
@@ -51,6 +59,7 @@ const NSSP_DEFAULT_COLUMNS = Object.keys(NSSP_COLUMN_LABELS);
 const NSSPView = ({ location, data, metadata }) => {
   const { handleLocationSelect, locationMessage, chartScale, showLegend } =
     useView();
+  const normalizedChartScale = normalizeChartScale(chartScale);
   const { colorScheme } = useMantineColorScheme();
   const [searchParams, setSearchParams] = useSearchParams();
   const [usMapData, setUsMapData] = useState(null);
@@ -92,10 +101,10 @@ const NSSPView = ({ location, data, metadata }) => {
           return value;
         }
 
-        return chartScale === "sqrt" ? Math.sqrt(Math.max(0, value)) : value;
+        return transformValueForScale(value, normalizedChartScale);
       });
     },
-    [chartScale],
+    [normalizedChartScale],
   );
 
   const getFullXRange = useCallback(() => {
@@ -499,7 +508,7 @@ const NSSPView = ({ location, data, metadata }) => {
 
   const rawYRange = useMemo(() => getYRangeFromTraces(rawTraces), [rawTraces]);
   const sqrtTicks = useMemo(() => {
-    if (chartScale !== "sqrt") {
+    if (normalizedChartScale !== "sqrt") {
       return null;
     }
 
@@ -510,7 +519,21 @@ const NSSPView = ({ location, data, metadata }) => {
           maximumFractionDigits: 2,
         })}%`,
     });
-  }, [chartScale, rawYRange]);
+  }, [normalizedChartScale, rawYRange]);
+
+  const log2Ticks = useMemo(() => {
+    if (normalizedChartScale !== "log2") {
+      return null;
+    }
+
+    return buildLog2Ticks({
+      rawRange: rawYRange,
+      formatValue: (value) =>
+        `${value.toLocaleString(undefined, {
+          maximumFractionDigits: 2,
+        })}%`,
+    });
+  }, [normalizedChartScale, rawYRange]);
 
   const plotTraces = useMemo(() => {
     if (!data?.series?.dates?.length) {
@@ -578,20 +601,37 @@ const NSSPView = ({ location, data, metadata }) => {
         range: xAxisRange || defaultRange,
       },
       yaxis: {
-        title: "Percent of visits",
-        range: chartScale === "log" ? undefined : yAxisRange,
-        autorange:
-          chartScale === "log"
-            ? true
-            : yAxisRange === null || selectedColumns.length === 0,
-        type: chartScale === "log" ? "log" : "linear",
-        tickmode: chartScale === "sqrt" && sqrtTicks ? "array" : undefined,
+        title: `Percent of visits${getScaleTitleSuffix(normalizedChartScale)}`,
+        range: isPlotlyLogScale(normalizedChartScale) ? undefined : yAxisRange,
+        autorange: isPlotlyLogScale(normalizedChartScale)
+          ? true
+          : yAxisRange === null || selectedColumns.length === 0,
+        type: isPlotlyLogScale(normalizedChartScale) ? "log" : "linear",
+        tickmode:
+          (normalizedChartScale === "sqrt" && sqrtTicks) ||
+          (normalizedChartScale === "log2" && log2Ticks)
+            ? "array"
+            : undefined,
         tickvals:
-          chartScale === "sqrt" && sqrtTicks ? sqrtTicks.tickvals : undefined,
+          normalizedChartScale === "sqrt" && sqrtTicks
+            ? sqrtTicks.tickvals
+            : normalizedChartScale === "log2" && log2Ticks
+              ? log2Ticks.tickvals
+              : undefined,
         ticktext:
-          chartScale === "sqrt" && sqrtTicks ? sqrtTicks.ticktext : undefined,
-        tickformat: chartScale === "sqrt" ? undefined : ".2f",
-        ticksuffix: chartScale === "sqrt" ? undefined : "%",
+          normalizedChartScale === "sqrt" && sqrtTicks
+            ? sqrtTicks.ticktext
+            : normalizedChartScale === "log2" && log2Ticks
+              ? log2Ticks.ticktext
+              : undefined,
+        tickformat:
+          normalizedChartScale === "sqrt" || normalizedChartScale === "log2"
+            ? undefined
+            : ".2f",
+        ticksuffix:
+          normalizedChartScale === "sqrt" || normalizedChartScale === "log2"
+            ? undefined
+            : "%",
       },
       showlegend: showLegend ?? true,
       legend: {
@@ -626,7 +666,7 @@ const NSSPView = ({ location, data, metadata }) => {
           : [],
     }),
     [
-      chartScale,
+      normalizedChartScale,
       colorScheme,
       defaultRange,
       fullRange,
@@ -634,6 +674,7 @@ const NSSPView = ({ location, data, metadata }) => {
       selectedColumns.length,
       showLegend,
       sqrtTicks,
+      log2Ticks,
       xAxisRange,
       yAxisRange,
     ],

--- a/app/src/hooks/useQuantileForecastTraces.js
+++ b/app/src/hooks/useQuantileForecastTraces.js
@@ -196,7 +196,7 @@ const useQuantileForecastTraces = ({
       y: groundTruthY,
       name: groundTruthLabel,
       type: "scatter",
-      mode: showMedian ? "lines+markers" : "lines",
+      mode: "lines+markers",
       line: { color: "black", width: groundTruthLineWidth, dash: "dash" },
       marker: { size: groundTruthMarkerSize, color: "black" },
     };

--- a/app/src/hooks/useQuantileForecastTraces.js
+++ b/app/src/hooks/useQuantileForecastTraces.js
@@ -135,7 +135,7 @@ const useQuantileForecastTraces = ({
   modelOrder = null,
   modelLineWidth = 2,
   modelMarkerSize = 6,
-  groundTruthLineWidth = 2,
+  groundTruthLineWidth = 1.5,
   groundTruthMarkerSize = 4,
   showLegendForFirstDate = true,
   fillMissingQuantiles = false,
@@ -197,7 +197,7 @@ const useQuantileForecastTraces = ({
       name: groundTruthLabel,
       type: "scatter",
       mode: "lines+markers",
-      line: { color: "black", width: groundTruthLineWidth, dash: "dash" },
+      line: { color: "black", width: groundTruthLineWidth, dash: "solid" },
       marker: { size: groundTruthMarkerSize, color: "black" },
     };
 

--- a/app/src/utils/scaleUtils.js
+++ b/app/src/utils/scaleUtils.js
@@ -17,6 +17,43 @@ const getYRangeFromTraces = (traces) => {
   return [minY, maxY];
 };
 
+const DEFAULT_CHART_SCALE = "linear";
+const SUPPORTED_CHART_SCALES = new Set(["linear", "log10", "log2", "sqrt"]);
+
+const normalizeChartScale = (scale) => {
+  if (scale === "log") return "log10";
+  return SUPPORTED_CHART_SCALES.has(scale) ? scale : DEFAULT_CHART_SCALE;
+};
+
+const isPlotlyLogScale = (scale) => normalizeChartScale(scale) === "log10";
+
+const getScaleTitleSuffix = (scale) => {
+  const normalizedScale = normalizeChartScale(scale);
+  if (normalizedScale === "log10") return " (log10)";
+  if (normalizedScale === "log2") return " (log2)";
+  if (normalizedScale === "sqrt") return " (sqrt)";
+  return "";
+};
+
+const transformValueForScale = (value, scale) => {
+  if (value === null || value === undefined) return value;
+
+  const numeric = Number(value);
+  if (Number.isNaN(numeric)) return value;
+
+  const normalizedScale = normalizeChartScale(scale);
+
+  if (normalizedScale === "sqrt") {
+    return Math.sqrt(Math.max(0, numeric));
+  }
+
+  if (normalizedScale === "log2") {
+    return numeric > 0 ? Math.log2(numeric) : null;
+  }
+
+  return numeric;
+};
+
 const buildSqrtTicks = ({
   rawRange,
   tickCount = 5,
@@ -56,4 +93,59 @@ const buildSqrtTicks = ({
   return { tickvals, ticktext };
 };
 
-export { getYRangeFromTraces, buildSqrtTicks };
+const buildLog2Ticks = ({
+  rawRange,
+  maxTickCount = 6,
+  formatValue = (value) =>
+    value.toLocaleString(undefined, { maximumFractionDigits: 2 }),
+}) => {
+  if (!rawRange || rawRange.length !== 2) return null;
+
+  const [rawMin, rawMax] = rawRange;
+  if (rawMax <= 0) return null;
+
+  const minValue = Math.max(Number.MIN_VALUE, rawMin);
+  const maxValue = Math.max(minValue, rawMax);
+
+  const startExponent = Math.floor(Math.log2(minValue));
+  const endExponent = Math.ceil(Math.log2(maxValue));
+
+  if (!Number.isFinite(startExponent) || !Number.isFinite(endExponent)) {
+    return null;
+  }
+
+  const exponentCount = endExponent - startExponent + 1;
+  const step = Math.max(1, Math.ceil(exponentCount / maxTickCount));
+  const tickvals = [];
+  const ticktext = [];
+
+  for (
+    let exponent = startExponent;
+    exponent <= endExponent;
+    exponent += step
+  ) {
+    const rawTick = 2 ** exponent;
+    tickvals.push(exponent);
+    ticktext.push(formatValue(rawTick));
+  }
+
+  if (tickvals[tickvals.length - 1] !== endExponent) {
+    const rawTick = 2 ** endExponent;
+    tickvals.push(endExponent);
+    ticktext.push(formatValue(rawTick));
+  }
+
+  return { tickvals, ticktext };
+};
+
+export {
+  DEFAULT_CHART_SCALE,
+  SUPPORTED_CHART_SCALES,
+  normalizeChartScale,
+  isPlotlyLogScale,
+  getScaleTitleSuffix,
+  transformValueForScale,
+  getYRangeFromTraces,
+  buildSqrtTicks,
+  buildLog2Ticks,
+};

--- a/app/src/utils/urlManager.js
+++ b/app/src/utils/urlManager.js
@@ -1,7 +1,6 @@
 import { DATASETS, APP_CONFIG } from "../config";
 import { parseForecastUrlState } from "./forecastRoutes";
-
-const DEFAULT_CHART_SCALE = "linear";
+import { DEFAULT_CHART_SCALE, normalizeChartScale } from "./scaleUtils";
 const DEFAULT_INTERVAL_VISIBILITY = {
   median: true,
   ci50: true,
@@ -72,7 +71,7 @@ export class URLParameterManager {
     const intervalsParam = this.searchParams.get("intervals");
     const legendParam = this.searchParams.get("legend");
 
-    const chartScale = scaleParam || DEFAULT_CHART_SCALE;
+    const chartScale = normalizeChartScale(scaleParam || DEFAULT_CHART_SCALE);
     let intervalVisibility = { ...DEFAULT_INTERVAL_VISIBILITY };
 
     if (intervalsParam === "none") {


### PR DESCRIPTION
- fix performance bug when you toggle forecast median off (gt points were disappearing as well)
- make the gt line on forecast plots solid instead of dashed
- rename log transformation to log10, add an additional transformation (log2)