### PR TITLE
Add past curves

### DIFF
--- a/app/src/components/FluPeak.jsx
+++ b/app/src/components/FluPeak.jsx
@@ -28,12 +28,6 @@ const toUtcDate = (dateString) => {
 
 const toIsoDate = (date) => date.toISOString().slice(0, 10);
 
-const shiftUtcDateByDays = (dateString, days) => {
-  const date = toUtcDate(dateString);
-  date.setUTCDate(date.getUTCDate() + days);
-  return toIsoDate(date);
-};
-
 const shiftUtcDateByMonths = (dateString, months) => {
   const date = toUtcDate(dateString);
   date.setUTCMonth(date.getUTCMonth() + months);
@@ -174,7 +168,6 @@ const FluPeak = ({
   const { colorScheme } = useMantineColorScheme();
   const groundTruth = data?.ground_truth;
   const [xAxisRange, setXAxisRange] = useState(null);
-  const [yAxisRange, setYAxisRange] = useState(null);
   const plotRef = useRef(null);
   const getDefaultRangeRef = useRef(() => null);
   const plotDataRef = useRef([]);
@@ -231,29 +224,11 @@ const FluPeak = ({
       return null;
     }
 
-    const selectedPeakDates =
-      selectedDates && selectedDates.length > 0
-        ? [...selectedDates].sort()
-        : peakDates && peakDates.length > 0
-          ? [...peakDates].sort().slice(-1)
-          : [];
+    const end = fullDataRange[1];
+    const start = shiftUtcDateByMonths(end, -9);
 
-    if (!selectedPeakDates.length) {
-      const end = fullDataRange[1];
-      return [shiftUtcDateByMonths(end, -6), shiftUtcDateByDays(end, 42)];
-    }
-
-    const initialStart = shiftUtcDateByMonths(selectedPeakDates[0], -3);
-    const initialEnd = shiftUtcDateByDays(
-      selectedPeakDates[selectedPeakDates.length - 1],
-      42,
-    );
-
-    return [
-      initialStart < fullDataRange[0] ? fullDataRange[0] : initialStart,
-      initialEnd > fullDataRange[1] ? fullDataRange[1] : initialEnd,
-    ];
-  }, [fullDataRange, peakDates, selectedDates]);
+    return [start < fullDataRange[0] ? fullDataRange[0] : start, end];
+  }, [fullDataRange]);
 
   const rangesliderRange = useMemo(() => fullDataRange, [fullDataRange]);
 
@@ -633,13 +608,13 @@ const FluPeak = ({
     plotDataRef.current = plotData;
   }, [defaultRange, plotData]);
 
-  useEffect(() => {
+  const displayedYRange = useMemo(() => {
     const currentRange = xAxisRange || defaultRange;
-    if (plotData.length > 0 && currentRange) {
-      setYAxisRange(calculateYRange(plotData, currentRange));
-    } else {
-      setYAxisRange(null);
+    if (!plotData.length || !currentRange) {
+      return null;
     }
+
+    return calculateYRange(plotData, currentRange);
   }, [plotData, xAxisRange, defaultRange, calculateYRange]);
 
   const handlePlotUpdate = useCallback(
@@ -728,10 +703,12 @@ const FluPeak = ({
           const baseTitle = "Flu Hospitalizations";
           return `${baseTitle}${getScaleTitleSuffix(normalizedChartScale)}`;
         })(),
-        range: isPlotlyLogScale(normalizedChartScale) ? undefined : yAxisRange,
+        range: isPlotlyLogScale(normalizedChartScale)
+          ? undefined
+          : displayedYRange,
         autorange: isPlotlyLogScale(normalizedChartScale)
           ? true
-          : yAxisRange === null,
+          : displayedYRange === null,
         type: isPlotlyLogScale(normalizedChartScale) ? "log" : "linear",
         tickmode:
           (normalizedChartScale === "sqrt" && sqrtTicks) ||
@@ -793,7 +770,7 @@ const FluPeak = ({
       defaultRange,
       rangesliderRange,
       xAxisRange,
-      yAxisRange,
+      displayedYRange,
       normalizedChartScale,
       sqrtTicks,
       log2Ticks,
@@ -830,7 +807,6 @@ const FluPeak = ({
             );
             isResettingRef.current = true;
             setXAxisRange(null);
-            setYAxisRange(nextYRange);
 
             Plotly.relayout(gd, {
               "xaxis.range": currentDefaultRange,

--- a/app/src/components/FluPeak.jsx
+++ b/app/src/components/FluPeak.jsx
@@ -1,10 +1,10 @@
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { Stack, useMantineColorScheme } from "@mantine/core";
 import Plot from "react-plotly.js";
+import Plotly from "plotly.js/dist/plotly";
 import ModelSelector from "./ModelSelector";
 import { getModelColor } from "../config/datasets";
 import { CHART_CONSTANTS } from "../constants/chart";
-import { getDataPath } from "../utils/paths";
 import {
   buildLog2Ticks,
   buildSqrtTicks,
@@ -16,6 +16,126 @@ import {
 } from "../utils/scaleUtils";
 import { buildPlotDownloadName } from "../utils/plotDownloadName";
 import { extendStableModelOrder } from "../utils/modelColorUtils";
+
+const FLU_PEAK_SEASON_START_MONTH_INDEX = 7;
+const FLU_PEAK_SEASON_START_MONTH = 8;
+const FLU_PEAK_SEASON_START_DAY = 1;
+
+const toUtcDate = (dateString) => {
+  const [year, month, day] = String(dateString).split("-").map(Number);
+  return new Date(Date.UTC(year, month - 1, day));
+};
+
+const toIsoDate = (date) => date.toISOString().slice(0, 10);
+
+const shiftUtcDateByDays = (dateString, days) => {
+  const date = toUtcDate(dateString);
+  date.setUTCDate(date.getUTCDate() + days);
+  return toIsoDate(date);
+};
+
+const shiftUtcDateByMonths = (dateString, months) => {
+  const date = toUtcDate(dateString);
+  date.setUTCMonth(date.getUTCMonth() + months);
+  return toIsoDate(date);
+};
+
+const padNumber = (value) => String(value).padStart(2, "0");
+
+const getFluPeakSeasonStartYear = (dateString) => {
+  const date = toUtcDate(dateString);
+  const year = date.getUTCFullYear();
+  return date.getUTCMonth() >= FLU_PEAK_SEASON_START_MONTH_INDEX
+    ? year
+    : year - 1;
+};
+
+const getFluPeakSeasonStartDate = (dateString) => {
+  const seasonStartYear = getFluPeakSeasonStartYear(dateString);
+  return `${seasonStartYear}-${padNumber(FLU_PEAK_SEASON_START_MONTH)}-${padNumber(FLU_PEAK_SEASON_START_DAY)}`;
+};
+
+const alignDateToFluPeakSeason = (dateString, anchorSeasonStartYear) => {
+  const date = toUtcDate(dateString);
+  const month = date.getUTCMonth();
+  const day = date.getUTCDate();
+  const alignedYear =
+    month >= FLU_PEAK_SEASON_START_MONTH_INDEX
+      ? anchorSeasonStartYear
+      : anchorSeasonStartYear + 1;
+
+  return new Date(Date.UTC(alignedYear, month, day)).toISOString().slice(0, 10);
+};
+
+const buildHistoricalPeakGroundTruthTraces = ({
+  groundTruth,
+  showOtherGroundTruthSeasons,
+}) => {
+  if (!showOtherGroundTruthSeasons || !groundTruth?.["wk inc flu hosp"]) {
+    return [];
+  }
+
+  const seasons = new Map();
+  (groundTruth.dates || []).forEach((dateString, index) => {
+    const value = groundTruth["wk inc flu hosp"][index];
+    if (value === null || value === undefined || Number.isNaN(Number(value))) {
+      return;
+    }
+
+    const seasonStartYear = getFluPeakSeasonStartYear(dateString);
+    if (!seasons.has(seasonStartYear)) {
+      seasons.set(seasonStartYear, []);
+    }
+
+    seasons.get(seasonStartYear).push({
+      actualDate: dateString,
+      value,
+    });
+  });
+
+  const seasonStartYears = Array.from(seasons.keys()).sort((a, b) => a - b);
+  if (seasonStartYears.length <= 1) {
+    return [];
+  }
+
+  const traces = [];
+  let showLegend = true;
+
+  seasonStartYears.forEach((anchorSeasonStartYear) => {
+    seasonStartYears.forEach((sourceSeasonStartYear) => {
+      if (anchorSeasonStartYear === sourceSeasonStartYear) {
+        return;
+      }
+
+      const sourcePoints = seasons.get(sourceSeasonStartYear) || [];
+      traces.push({
+        x: sourcePoints.map((point) =>
+          alignDateToFluPeakSeason(point.actualDate, anchorSeasonStartYear),
+        ),
+        y: sourcePoints.map((point) => point.value),
+        type: "scatter",
+        mode: "lines",
+        name: "Historical Seasons",
+        legendgroup: "history",
+        showlegend: showLegend,
+        line: { color: "#d3d3d3", width: 1.5 },
+        customdata: sourcePoints.map((point) => [
+          point.actualDate,
+          `${sourceSeasonStartYear}-${sourceSeasonStartYear + 1}`,
+          point.value,
+        ]),
+        hovertemplate:
+          "<b>Historical season</b><br>" +
+          "Source season: %{customdata[1]}<br>" +
+          "Original date: %{customdata[0]}<br>" +
+          "Hospitalizations: %{customdata[2]}<extra></extra>",
+      });
+      showLegend = false;
+    });
+  });
+
+  return traces;
+};
 
 // helper to convert Hex to RGBA for opacity control
 const hexToRgba = (hex, alpha) => {
@@ -42,7 +162,6 @@ const FluPeak = ({
   peaks,
   peakDates,
   peakModels,
-  peakLocation,
   windowSize,
   selectedModels,
   setSelectedModels,
@@ -50,10 +169,16 @@ const FluPeak = ({
   chartScale = "linear",
   intervalVisibility = { median: true, ci50: true, ci95: true },
   showLegend = true,
+  showOtherGroundTruthSeasons = false,
 }) => {
   const { colorScheme } = useMantineColorScheme();
   const groundTruth = data?.ground_truth;
-  const [nhsnData, setNhsnData] = useState(null);
+  const [xAxisRange, setXAxisRange] = useState(null);
+  const [yAxisRange, setYAxisRange] = useState(null);
+  const plotRef = useRef(null);
+  const getDefaultRangeRef = useRef(() => null);
+  const plotDataRef = useRef([]);
+  const isResettingRef = useRef(false);
   const showMedian = intervalVisibility?.median ?? true;
   const show50 = intervalVisibility?.ci50 ?? true;
   const show95 = intervalVisibility?.ci95 ?? true;
@@ -67,38 +192,6 @@ const FluPeak = ({
     stableModelOrderRef.current = nextOrder;
     return nextOrder;
   }, [selectedModels]);
-
-  const getNormalizedDate = (dateStr) => {
-    const d = new Date(dateStr);
-    const month = d.getUTCMonth();
-    const baseYear = month >= 7 ? 2000 : 2001;
-    d.setUTCFullYear(baseYear);
-    return d;
-  };
-
-  useEffect(() => {
-    if (!peakLocation) return;
-    const fetchNhsnData = async () => {
-      try {
-        const dataUrl = getDataPath(`nhsn/${peakLocation}_nhsn.json`);
-        const response = await fetch(dataUrl);
-        if (!response.ok) {
-          setNhsnData(null);
-          return;
-        }
-        const json = await response.json();
-        const dates = json.series?.dates || [];
-        const admissions = json.series?.["Total Influenza Admissions"] || [];
-
-        if (dates.length > 0 && admissions.length > 0) {
-          setNhsnData({ dates, admissions });
-        }
-      } catch (err) {
-        console.error(err);
-      }
-    };
-    fetchNhsnData();
-  }, [peakLocation]);
 
   const activePeakModels = useMemo(() => {
     const activeModelSet = new Set();
@@ -120,88 +213,117 @@ const FluPeak = ({
     return activeModelSet;
   }, [peaks, selectedDates, peakDates]);
 
+  const fullDataRange = useMemo(() => {
+    const dateCandidates = [
+      ...(groundTruth?.dates || []),
+      ...(peakDates || []),
+    ].sort();
+
+    if (!dateCandidates.length) {
+      return null;
+    }
+
+    return [dateCandidates[0], dateCandidates[dateCandidates.length - 1]];
+  }, [groundTruth, peakDates]);
+
+  const defaultRange = useMemo(() => {
+    if (!fullDataRange) {
+      return null;
+    }
+
+    const selectedPeakDates =
+      selectedDates && selectedDates.length > 0
+        ? [...selectedDates].sort()
+        : peakDates && peakDates.length > 0
+          ? [...peakDates].sort().slice(-1)
+          : [];
+
+    if (!selectedPeakDates.length) {
+      const end = fullDataRange[1];
+      return [shiftUtcDateByMonths(end, -6), shiftUtcDateByDays(end, 42)];
+    }
+
+    const initialStart = shiftUtcDateByMonths(selectedPeakDates[0], -3);
+    const initialEnd = shiftUtcDateByDays(
+      selectedPeakDates[selectedPeakDates.length - 1],
+      42,
+    );
+
+    return [
+      initialStart < fullDataRange[0] ? fullDataRange[0] : initialStart,
+      initialEnd > fullDataRange[1] ? fullDataRange[1] : initialEnd,
+    ];
+  }, [fullDataRange, peakDates, selectedDates]);
+
+  const rangesliderRange = useMemo(() => fullDataRange, [fullDataRange]);
+
+  const calculateYRange = useCallback((chartData, xRange) => {
+    if (!chartData?.length || !xRange) {
+      return null;
+    }
+
+    let minY = Infinity;
+    let maxY = -Infinity;
+    const [startX, endX] = xRange;
+    const startDate = new Date(startX);
+    const endDate = new Date(endX);
+
+    chartData.forEach((trace) => {
+      if (!trace.x || !trace.y) return;
+
+      for (let index = 0; index < trace.x.length; index += 1) {
+        const pointDate = new Date(trace.x[index]);
+        if (pointDate < startDate || pointDate > endDate) {
+          continue;
+        }
+
+        const value = Number(trace.y[index]);
+        if (Number.isNaN(value)) {
+          continue;
+        }
+
+        minY = Math.min(minY, value);
+        maxY = Math.max(maxY, value);
+      }
+    });
+
+    if (minY === Infinity || maxY === -Infinity) {
+      return null;
+    }
+
+    const padding = maxY * (CHART_CONSTANTS.Y_AXIS_PADDING_PERCENT / 100);
+    return [Math.max(0, minY - padding), maxY + padding];
+  }, []);
+
   const { plotData, rawYRange } = useMemo(() => {
     const traces = [];
 
-    // Historic data (NHSN)
-    if (nhsnData && nhsnData.dates && nhsnData.admissions) {
-      const seasons = {};
-      nhsnData.dates.forEach((dateStr, index) => {
-        const date = new Date(dateStr);
-        const year = date.getUTCFullYear();
-        const month = date.getUTCMonth() + 1;
-        const seasonStartYear = month >= 8 ? year : year - 1;
-        const seasonKey = `${seasonStartYear}-${seasonStartYear + 1}`;
+    traces.push(
+      ...buildHistoricalPeakGroundTruthTraces({
+        groundTruth,
+        showOtherGroundTruthSeasons,
+      }),
+    );
 
-        if (!seasons[seasonKey]) seasons[seasonKey] = { x: [], y: [] };
-        seasons[seasonKey].x.push(getNormalizedDate(dateStr));
-        seasons[seasonKey].y.push(nhsnData.admissions[index]);
-      });
-      const currentSeasonKey = "2025-2026";
-      const sortedKeys = Object.keys(seasons)
-        .filter((key) => key !== currentSeasonKey)
-        .sort();
-
-      // Dummy data for legend
-      if (sortedKeys.length > 0) {
-        const firstKey = sortedKeys[0];
-        traces.push({
-          x: [seasons[firstKey].x[0]],
-          y: [seasons[firstKey].y[0]],
-          name: "Historical Seasons",
-          legendgroup: "history",
-          showlegend: true,
-          mode: "lines",
-          line: { color: "#d3d3d3", width: 1.5 },
-          hoverinfo: "skip",
-        });
-      }
-
-      sortedKeys.forEach((seasonKey) => {
-        traces.push({
-          x: seasons[seasonKey].x,
-          y: seasons[seasonKey].y,
-          name: `${seasonKey} Season`,
-          legendgroup: "history",
-          type: "scatter",
-          mode: "lines",
-          line: { color: "#d3d3d3", width: 1.5 },
-          connectgaps: true,
-          showlegend: false,
-          hoverinfo: "name+y",
-        });
-      });
-    }
-
-    // Current season (gt data)
+    // Continuous ground truth data
     const targetKey = "wk inc flu hosp";
-    const SEASON_START_DATE = "2025-08-01";
     if (groundTruth && groundTruth[targetKey] && groundTruth.dates) {
-      const { dates, values } = groundTruth.dates.reduce(
-        (acc, date, index) => {
-          if (date >= SEASON_START_DATE) {
-            acc.dates.push(getNormalizedDate(date));
-            acc.values.push(groundTruth[targetKey][index]);
-          }
-          return acc;
-        },
-        { dates: [], values: [] },
-      );
-
+      const dates = [...groundTruth.dates];
+      const values = [...groundTruth[targetKey]];
       if (dates.length > 0) {
         traces.push({
           x: dates,
           y: values,
-          name: "Current season",
+          name: "Observed",
           type: "scatter",
           mode: "lines+markers",
           line: { color: "black", width: 2, dash: "dash" },
           showlegend: true,
           marker: { size: 4, color: "black" },
           hovertemplate:
-            "<b>Current Season</b><br>" +
+            "<b>Observed</b><br>" +
             "Hospitalizations: %{y}<br>" +
-            "Date: %{x|%b %d}<extra></extra>",
+            "Date: %{x}<extra></extra>",
         });
       }
     }
@@ -288,7 +410,7 @@ const FluPeak = ({
           }
           if (!bestDateStr) return;
 
-          const normalizedDate = getNormalizedDate(bestDateStr);
+          const normalizedDate = bestDateStr;
           // Gradient Opacity Calculation
           const minOpacity = 0.4;
           const alpha =
@@ -346,10 +468,7 @@ const FluPeak = ({
             // 95% horizontal whisker (dates)
             if (show95 && lowDate95 && highDate95) {
               traces.push({
-                x: [
-                  getNormalizedDate(lowDate95),
-                  getNormalizedDate(highDate95),
-                ],
+                x: [lowDate95, highDate95],
                 y: [medianVal, medianVal],
                 mode: "lines+markers",
                 line: {
@@ -372,10 +491,7 @@ const FluPeak = ({
             // 50% horizontal whisker (dates)
             if (show50 && lowDate50 && highDate50) {
               traces.push({
-                x: [
-                  getNormalizedDate(lowDate50),
-                  getNormalizedDate(highDate50),
-                ],
+                x: [lowDate50, highDate50],
                 y: [medianVal, medianVal],
                 mode: "lines",
                 line: {
@@ -390,7 +506,7 @@ const FluPeak = ({
             }
           }
           if (showMedian) {
-            xValues.push(getNormalizedDate(bestDateStr));
+            xValues.push(bestDateStr);
             yValues.push(medianVal);
             pointColors.push(dynamicColor);
           }
@@ -500,7 +616,6 @@ const FluPeak = ({
     return { plotData: scaledTraces, rawYRange: rawRange };
   }, [
     groundTruth,
-    nhsnData,
     peaks,
     selectedModels,
     selectedDates,
@@ -508,9 +623,41 @@ const FluPeak = ({
     showMedian,
     show50,
     show95,
+    showOtherGroundTruthSeasons,
     normalizedChartScale,
     stableModelOrder,
   ]);
+
+  useEffect(() => {
+    getDefaultRangeRef.current = () => defaultRange;
+    plotDataRef.current = plotData;
+  }, [defaultRange, plotData]);
+
+  useEffect(() => {
+    const currentRange = xAxisRange || defaultRange;
+    if (plotData.length > 0 && currentRange) {
+      setYAxisRange(calculateYRange(plotData, currentRange));
+    } else {
+      setYAxisRange(null);
+    }
+  }, [plotData, xAxisRange, defaultRange, calculateYRange]);
+
+  const handlePlotUpdate = useCallback(
+    (figure) => {
+      if (isResettingRef.current) {
+        isResettingRef.current = false;
+        return;
+      }
+
+      if (figure && figure["xaxis.range"]) {
+        const nextXRange = figure["xaxis.range"];
+        if (JSON.stringify(nextXRange) !== JSON.stringify(xAxisRange)) {
+          setXAxisRange(nextXRange);
+        }
+      }
+    },
+    [xAxisRange],
+  );
 
   const sqrtTicks = useMemo(() => {
     if (normalizedChartScale !== "sqrt") return null;
@@ -563,14 +710,28 @@ const FluPeak = ({
       hoverlabel: { namelength: -1 },
       dragmode: false,
       xaxis: {
-        tickformat: "%b",
+        range: xAxisRange || defaultRange,
+        rangeslider: rangesliderRange ? { range: rangesliderRange } : undefined,
+        rangeselector: {
+          buttons: [
+            { count: 1, label: "1m", step: "month", stepmode: "backward" },
+            { count: 6, label: "6m", step: "month", stepmode: "backward" },
+            { step: "all", label: "all" },
+          ],
+        },
+        showline: true,
+        linewidth: 1,
+        linecolor: colorScheme === "dark" ? "#aaa" : "#444",
       },
       yaxis: {
         title: (() => {
           const baseTitle = "Flu Hospitalizations";
           return `${baseTitle}${getScaleTitleSuffix(normalizedChartScale)}`;
         })(),
-        rangemode: "tozero",
+        range: isPlotlyLogScale(normalizedChartScale) ? undefined : yAxisRange,
+        autorange: isPlotlyLogScale(normalizedChartScale)
+          ? true
+          : yAxisRange === null,
         type: isPlotlyLogScale(normalizedChartScale) ? "log" : "linear",
         tickmode:
           (normalizedChartScale === "sqrt" && sqrtTicks) ||
@@ -593,15 +754,14 @@ const FluPeak = ({
 
       // dynamic gray shading section
       shapes: selectedDates.flatMap((dateStr) => {
-        const normalizedRefDate = getNormalizedDate(dateStr);
-        const seasonStart = new Date("2000-08-01");
+        const seasonStart = getFluPeakSeasonStartDate(dateStr);
         return [
           {
             type: "rect",
             xref: "x",
             yref: "paper",
             x0: seasonStart,
-            x1: normalizedRefDate,
+            x1: dateStr,
             y0: 0,
             y1: 1,
             fillcolor:
@@ -613,8 +773,8 @@ const FluPeak = ({
           },
           {
             type: "line",
-            x0: normalizedRefDate,
-            x1: normalizedRefDate,
+            x0: dateStr,
+            x1: dateStr,
             y0: 0,
             y1: 1,
             yref: "paper",
@@ -630,6 +790,10 @@ const FluPeak = ({
       colorScheme,
       windowSize,
       selectedDates,
+      defaultRange,
+      rangesliderRange,
+      xAxisRange,
+      yAxisRange,
       normalizedChartScale,
       sqrtTicks,
       log2Ticks,
@@ -645,13 +809,39 @@ const FluPeak = ({
       modeBarPosition: "left",
       scrollZoom: false,
       doubleClick: "reset",
-      modeBarButtonsToRemove: ["select2d", "lasso2d"],
+      modeBarButtonsToRemove: ["select2d", "lasso2d", "resetScale2d"],
       toImageButtonOptions: {
         format: "png",
         filename: buildPlotDownloadName("peak-plot"),
       },
+      modeBarButtonsToAdd: [
+        {
+          name: "Reset view",
+          icon: Plotly.Icons.home,
+          click: function (gd) {
+            const currentDefaultRange = getDefaultRangeRef.current();
+            const currentPlotData = plotDataRef.current;
+
+            if (!currentDefaultRange) return;
+
+            const nextYRange = calculateYRange(
+              currentPlotData,
+              currentDefaultRange,
+            );
+            isResettingRef.current = true;
+            setXAxisRange(null);
+            setYAxisRange(nextYRange);
+
+            Plotly.relayout(gd, {
+              "xaxis.range": currentDefaultRange,
+              "yaxis.range": nextYRange,
+              "yaxis.autorange": nextYRange === null,
+            });
+          },
+        },
+      ],
     }),
-    [],
+    [calculateYRange],
   );
 
   return (
@@ -663,11 +853,13 @@ const FluPeak = ({
             `}</style>
       <div style={{ width: "100%", minHeight: "400px" }}>
         <Plot
+          ref={plotRef}
           data={plotData}
           layout={layout}
           config={config}
           style={{ width: "100%", height: "100%" }}
           useResizeHandler={true}
+          onRelayout={(figure) => handlePlotUpdate(figure)}
         />
       </div>
       <Stack gap={2}>

--- a/app/src/components/ForecastPlotView.jsx
+++ b/app/src/components/ForecastPlotView.jsx
@@ -19,6 +19,11 @@ import { useView } from "../hooks/useView";
 import { getDatasetTitleFromView } from "../utils/datasetUtils";
 import { buildPlotDownloadName } from "../utils/plotDownloadName";
 import { getOfficialModels } from "../utils/forecastleScoring";
+import {
+  getHubSeasonStartDate,
+  getSeasonDateRange,
+  getSeasonStartYear,
+} from "../utils/forecastSeasons";
 
 const FORECAST_DATASET_KEYS_BY_VIEW = {
   fludetailed: "flusight",
@@ -56,7 +61,13 @@ const ForecastPlotView = ({
   const plotRef = useRef(null);
   const isResettingRef = useRef(false);
   const { colorScheme } = useMantineColorScheme();
-  const { chartScale, intervalVisibility, showLegend, viewType } = useView();
+  const {
+    chartScale,
+    intervalVisibility,
+    showLegend,
+    showOtherGroundTruthSeasons,
+    viewType,
+  } = useView();
   const stateName = data?.metadata?.location_name;
   const hubName = getDatasetTitleFromView(viewType) || data?.metadata?.dataset;
 
@@ -122,7 +133,11 @@ const ForecastPlotView = ({
     [resolvedForecastTarget],
   );
 
-  const { traces: projectionsData, rawYRange } = useQuantileForecastTraces({
+  const {
+    traces: projectionsData,
+    rawYRange,
+    hasForecastTraces,
+  } = useQuantileForecastTraces({
     groundTruth,
     forecasts,
     selectedDates,
@@ -140,6 +155,8 @@ const ForecastPlotView = ({
     showMedian,
     show50,
     show95,
+    showOtherGroundTruthSeasons,
+    viewType,
     transformY: manualScaleTransform,
     baselineModelName,
     groundTruthHoverFormatter: manualScaleTransform
@@ -236,6 +253,43 @@ const ForecastPlotView = ({
     return buildLog2Ticks({ rawRange: rawYRange });
   }, [normalizedChartScale, rawYRange]);
 
+  const seasonDividerShapes = useMemo(() => {
+    if (!showOtherGroundTruthSeasons || !groundTruth?.dates?.length) {
+      return [];
+    }
+
+    const hubSeasonStartDate = getHubSeasonStartDate(viewType);
+    const dividerYears = Array.from(
+      new Set(
+        groundTruth.dates
+          .filter((dateString) =>
+            hubSeasonStartDate ? dateString >= hubSeasonStartDate : true,
+          )
+          .map((dateString) => getSeasonStartYear(dateString)),
+      ),
+    )
+      .sort((a, b) => a - b)
+      .slice(1);
+
+    return dividerYears.map((seasonStartYear) => {
+      const { start } = getSeasonDateRange(seasonStartYear);
+      return {
+        type: "line",
+        x0: start,
+        x1: start,
+        y0: 0,
+        y1: 1,
+        yref: "paper",
+        line: {
+          color: colorScheme === "dark" ? "#495057" : "#ced4da",
+          width: 1,
+          dash: "dot",
+        },
+        layer: "below",
+      };
+    });
+  }, [colorScheme, groundTruth, showOtherGroundTruthSeasons, viewType]);
+
   const layout = useMemo(() => {
     const baseLayout = {
       autosize: true,
@@ -314,22 +368,25 @@ const ForecastPlotView = ({
               ? log2Ticks.ticktext
               : undefined,
       },
-      shapes: selectedDates.map((date) => {
-        const shiftedDate = shiftDateStringByDays(date, -3);
-        return {
-          type: "line",
-          x0: shiftedDate,
-          x1: shiftedDate,
-          y0: 0,
-          y1: 1,
-          yref: "paper",
-          line: {
-            color: "red",
-            width: 1,
-            dash: "dash",
-          },
-        };
-      }),
+      shapes: [
+        ...seasonDividerShapes,
+        ...selectedDates.map((date) => {
+          const shiftedDate = shiftDateStringByDays(date, -3);
+          return {
+            type: "line",
+            x0: shiftedDate,
+            x1: shiftedDate,
+            y0: 0,
+            y1: 1,
+            yref: "paper",
+            line: {
+              color: "red",
+              width: 1,
+              dash: "dash",
+            },
+          };
+        }),
+      ],
     };
 
     if (layoutOverrides) {
@@ -350,6 +407,7 @@ const ForecastPlotView = ({
     sqrtTicks,
     log2Ticks,
     showLegend,
+    seasonDividerShapes,
   ]);
 
   const config = useMemo(() => {
@@ -404,7 +462,7 @@ const ForecastPlotView = ({
     return baseConfig;
   }, [calculateYRange, configOverrides]);
 
-  const hasForecasts = projectionsData.length > 1;
+  const hasForecasts = hasForecastTraces;
   if (requireTarget && !selectedTarget) {
     return (
       <Stack align="center" justify="center" style={{ height: "300px" }}>

--- a/app/src/components/ForecastPlotView.jsx
+++ b/app/src/components/ForecastPlotView.jsx
@@ -20,7 +20,7 @@ import { getDatasetTitleFromView } from "../utils/datasetUtils";
 import { buildPlotDownloadName } from "../utils/plotDownloadName";
 import { getOfficialModels } from "../utils/forecastleScoring";
 import {
-  getHubSeasonStartDate,
+  getEarliestGroundTruthSeasonStartDate,
   getSeasonDateRange,
   getSeasonStartYear,
 } from "../utils/forecastSeasons";
@@ -258,7 +258,10 @@ const ForecastPlotView = ({
       return [];
     }
 
-    const hubSeasonStartDate = getHubSeasonStartDate(viewType);
+    const hubSeasonStartDate = getEarliestGroundTruthSeasonStartDate({
+      groundTruth,
+      target: resolvedForecastTarget,
+    });
     const dividerYears = Array.from(
       new Set(
         groundTruth.dates
@@ -288,7 +291,12 @@ const ForecastPlotView = ({
         layer: "below",
       };
     });
-  }, [colorScheme, groundTruth, showOtherGroundTruthSeasons, viewType]);
+  }, [
+    colorScheme,
+    groundTruth,
+    resolvedForecastTarget,
+    showOtherGroundTruthSeasons,
+  ]);
 
   const layout = useMemo(() => {
     const baseLayout = {

--- a/app/src/components/StateSelector.jsx
+++ b/app/src/components/StateSelector.jsx
@@ -305,6 +305,9 @@ const StateSelector = () => {
                 setShowLegend={setShowLegend}
                 showOtherGroundTruthSeasons={showOtherGroundTruthSeasons}
                 setShowOtherGroundTruthSeasons={setShowOtherGroundTruthSeasons}
+                disableOtherGroundTruthSeasons={
+                  viewType === "nhsnall" || viewType === "nsspall"
+                }
                 showIntervals={viewType !== "nhsnall" && viewType !== "nsspall"}
               />
             </Accordion.Panel>

--- a/app/src/components/StateSelector.jsx
+++ b/app/src/components/StateSelector.jsx
@@ -88,6 +88,8 @@ const StateSelector = () => {
     setIntervalVisibility,
     showLegend,
     setShowLegend,
+    showOtherGroundTruthSeasons,
+    setShowOtherGroundTruthSeasons,
   } = useView();
 
   const [states, setStates] = useState([]);
@@ -301,6 +303,8 @@ const StateSelector = () => {
                 setIntervalVisibility={setIntervalVisibility}
                 showLegend={showLegend}
                 setShowLegend={setShowLegend}
+                showOtherGroundTruthSeasons={showOtherGroundTruthSeasons}
+                setShowOtherGroundTruthSeasons={setShowOtherGroundTruthSeasons}
                 showIntervals={viewType !== "nhsnall" && viewType !== "nsspall"}
               />
             </Accordion.Panel>

--- a/app/src/components/controls/ForecastChartControls.jsx
+++ b/app/src/components/controls/ForecastChartControls.jsx
@@ -104,7 +104,6 @@ const ForecastChartControls = ({
             size="sm"
             onLabel="On"
             offLabel="Off"
-            label="Show other seasons"
           />
         </Group>
       )}

--- a/app/src/components/controls/ForecastChartControls.jsx
+++ b/app/src/components/controls/ForecastChartControls.jsx
@@ -29,6 +29,7 @@ const ForecastChartControls = ({
   setShowLegend,
   showOtherGroundTruthSeasons = false,
   setShowOtherGroundTruthSeasons = null,
+  disableOtherGroundTruthSeasons = false,
   showIntervals = true,
   intervalOptions = INTERVAL_OPTIONS,
 }) => {
@@ -93,11 +94,16 @@ const ForecastChartControls = ({
       </Group>
       {typeof setShowOtherGroundTruthSeasons === "function" && (
         <Group align="center" gap="md">
-          <Text size="xs" c="dimmed" style={{ minWidth: 90 }}>
+          <Text
+            size="xs"
+            c={disableOtherGroundTruthSeasons ? "gray.6" : "dimmed"}
+            style={{ minWidth: 90 }}
+          >
             Other GT
           </Text>
           <Switch
             checked={showOtherGroundTruthSeasons}
+            disabled={disableOtherGroundTruthSeasons}
             onChange={(event) =>
               setShowOtherGroundTruthSeasons(event.currentTarget.checked)
             }

--- a/app/src/components/controls/ForecastChartControls.jsx
+++ b/app/src/components/controls/ForecastChartControls.jsx
@@ -27,6 +27,8 @@ const ForecastChartControls = ({
   setIntervalVisibility,
   showLegend,
   setShowLegend,
+  showOtherGroundTruthSeasons = false,
+  setShowOtherGroundTruthSeasons = null,
   showIntervals = true,
   intervalOptions = INTERVAL_OPTIONS,
 }) => {
@@ -89,6 +91,23 @@ const ForecastChartControls = ({
           offLabel="Off"
         />
       </Group>
+      {typeof setShowOtherGroundTruthSeasons === "function" && (
+        <Group align="center" gap="md">
+          <Text size="xs" c="dimmed" style={{ minWidth: 90 }}>
+            Other GT
+          </Text>
+          <Switch
+            checked={showOtherGroundTruthSeasons}
+            onChange={(event) =>
+              setShowOtherGroundTruthSeasons(event.currentTarget.checked)
+            }
+            size="sm"
+            onLabel="On"
+            offLabel="Off"
+            label="Show other seasons"
+          />
+        </Group>
+      )}
     </Stack>
   );
 };

--- a/app/src/components/myplots/MiniPlot.jsx
+++ b/app/src/components/myplots/MiniPlot.jsx
@@ -22,21 +22,16 @@ import {
   normalizeChartScale,
   transformValueForScale,
 } from "../../utils/scaleUtils";
+import {
+  FLU_PEAK_GROUND_TRUTH_START,
+  FLU_PEAK_NORMALIZED_X_RANGE,
+  getNormalizedPeakDate,
+} from "../../utils/forecastSeasons";
 
 const NSSP_COLUMN_LABELS = {
   percent_visits_covid: "COVID-19",
   percent_visits_influenza: "Influenza",
   percent_visits_rsv: "RSV",
-};
-
-const CURRENT_FLU_SEASON_START = "2025-08-01";
-
-const getNormalizedPeakDate = (dateStr) => {
-  const date = new Date(dateStr);
-  const month = date.getUTCMonth();
-  const baseYear = month >= 7 ? 2000 : 2001;
-  date.setUTCFullYear(baseYear);
-  return date;
 };
 
 const toRgba = (hex, alpha) => {
@@ -173,7 +168,7 @@ const MiniPlot = ({ plot, onMetadataLoad, plotHeight = 210 }) => {
     if (groundTruth?.["wk inc flu hosp"] && groundTruth?.dates) {
       const currentSeason = groundTruth.dates.reduce(
         (accumulator, date, index) => {
-          if (date >= CURRENT_FLU_SEASON_START) {
+          if (date >= FLU_PEAK_GROUND_TRUTH_START) {
             const rawValue = groundTruth["wk inc flu hosp"][index];
             accumulator.x.push(getNormalizedPeakDate(date));
             accumulator.y.push(transformY(rawValue));
@@ -341,7 +336,7 @@ const MiniPlot = ({ plot, onMetadataLoad, plotHeight = 210 }) => {
             : data.series.dates[data.series.dates.length - 1],
         ];
       } else if (isFluPeak) {
-        xRange = ["2000-08-01", "2001-05-31"];
+        xRange = FLU_PEAK_NORMALIZED_X_RANGE;
       } else if (plot.settings.dates?.length > 0) {
         const sortedDates = [...plot.settings.dates].sort();
         const earliestDate = new Date(sortedDates[0]);

--- a/app/src/components/views/FluView.jsx
+++ b/app/src/components/views/FluView.jsx
@@ -22,9 +22,13 @@ const FluView = ({
   peaks,
   availablePeakDates,
   availablePeakModels,
-  peakLocation,
 }) => {
-  const { chartScale, intervalVisibility, showLegend } = useView();
+  const {
+    chartScale,
+    intervalVisibility,
+    showLegend,
+    showOtherGroundTruthSeasons,
+  } = useView();
   const forecasts = data?.forecasts;
   const stableModelOrderRef = useRef([]);
   const stableModelOrder = useMemo(() => {
@@ -224,10 +228,10 @@ const FluView = ({
           setSelectedModels={setSelectedModels}
           selectedDates={selectedDates}
           windowSize={windowSize}
-          peakLocation={peakLocation}
           chartScale={chartScale}
           intervalVisibility={intervalVisibility}
           showLegend={showLegend}
+          showOtherGroundTruthSeasons={showOtherGroundTruthSeasons}
         />
       </>
     );

--- a/app/src/components/views/MetroCastView.jsx
+++ b/app/src/components/views/MetroCastView.jsx
@@ -61,6 +61,7 @@ const MetroPlotCard = ({
   chartScale,
   intervalVisibility,
   showLegend = true,
+  showOtherGroundTruthSeasons = false,
 }) => {
   const groundTruth = locationData?.ground_truth;
   const forecasts = locationData?.forecasts;
@@ -106,7 +107,11 @@ const MetroPlotCard = ({
     return (value) => transformValueForScale(value, normalizedChartScale);
   }, [normalizedChartScale]);
 
-  const { traces: projectionsData, rawYRange } = useQuantileForecastTraces({
+  const {
+    traces: projectionsData,
+    rawYRange,
+    hasForecastTraces,
+  } = useQuantileForecastTraces({
     groundTruth,
     forecasts,
     selectedDates,
@@ -125,6 +130,8 @@ const MetroPlotCard = ({
     showMedian,
     show50,
     show95,
+    showOtherGroundTruthSeasons,
+    viewType: "metrocast_forecasts",
     transformY: manualScaleTransform,
     groundTruthHoverFormatter: manualScaleTransform
       ? (value) => Number(value).toFixed(2)
@@ -154,7 +161,7 @@ const MetroPlotCard = ({
     });
   }, [normalizedChartScale, rawYRange]);
 
-  const hasForecasts = projectionsData.length > 1;
+  const hasForecasts = hasForecastTraces;
 
   const PlotContent = (
     <>
@@ -366,6 +373,7 @@ const MetroCastView = ({
     chartScale,
     intervalVisibility,
     showLegend,
+    showOtherGroundTruthSeasons,
     viewType,
   } = useView();
   const [childData, setChildData] = useState({});
@@ -459,6 +467,7 @@ const MetroCastView = ({
         chartScale={chartScale}
         intervalVisibility={intervalVisibility}
         showLegend={showLegend}
+        showOtherGroundTruthSeasons={showOtherGroundTruthSeasons}
       />
       {stateCode && (
         <Stack gap="md">
@@ -490,6 +499,7 @@ const MetroCastView = ({
                       chartScale={chartScale}
                       intervalVisibility={intervalVisibility}
                       showLegend={showLegend}
+                      showOtherGroundTruthSeasons={showOtherGroundTruthSeasons}
                     />
                   </UnstyledButton>
                 ))}

--- a/app/src/config/forecastle.js
+++ b/app/src/config/forecastle.js
@@ -37,7 +37,7 @@ export const FORECASTLE_CONFIG = {
    * Historical data display ranges
    * Controls how much historical data to show in the game charts
    *
-   * - 'seasonStart': Show data since July 1st of the current season
+   * - 'seasonStart': Show data since September 1st of the current season
    * - Number: Show last N weeks of data
    */
   historyDisplay: {

--- a/app/src/contexts/ViewContext.jsx
+++ b/app/src/contexts/ViewContext.jsx
@@ -12,6 +12,7 @@ import {
   isPathBasedForecastView,
   parseForecastUrlState,
 } from "../utils/forecastRoutes";
+import { FLU_PEAK_AVAILABLE_DATE_START } from "../utils/forecastSeasons";
 
 const METRO_STATE_MAP = {
   Colorado: "CO",
@@ -390,7 +391,6 @@ export const ViewProvider = ({ children }) => {
   );
   const [showOtherGroundTruthSeasons, setShowOtherGroundTruthSeasons] =
     useState(() => urlManager.getAdvancedParams().showOtherGroundTruthSeasons);
-  const CURRENT_FLU_SEASON_START = "2025-11-01"; // !! CRITICAL !!: need to change this manually based on the season (for flu peak view)
 
   const {
     data,
@@ -468,7 +468,7 @@ export const ViewProvider = ({ children }) => {
   const availableDatesToExpose = useMemo(() => {
     if (viewType === "flu_peak") {
       return (availablePeakDates || []).filter(
-        (date) => date >= CURRENT_FLU_SEASON_START,
+        (date) => date >= FLU_PEAK_AVAILABLE_DATE_START,
       );
     }
     return availableDates || [];
@@ -951,7 +951,7 @@ export const ViewProvider = ({ children }) => {
     handleTargetSelect,
     peaks,
     availablePeakDates: (availablePeakDates || []).filter(
-      (date) => date >= CURRENT_FLU_SEASON_START,
+      (date) => date >= FLU_PEAK_AVAILABLE_DATE_START,
     ),
     availablePeakModels,
     chartScale,

--- a/app/src/contexts/ViewContext.jsx
+++ b/app/src/contexts/ViewContext.jsx
@@ -802,12 +802,25 @@ export const ViewProvider = ({ children }) => {
     if (!isForecastPage) {
       return;
     }
+
+    const isSurveillanceView = viewType === "nhsnall" || viewType === "nsspall";
     const {
       chartScale: urlScale,
       intervalVisibility: urlIntervals,
       showLegend: urlLegend,
       showOtherGroundTruthSeasons: urlShowOtherGroundTruthSeasons,
     } = urlManager.getAdvancedParams();
+
+    if (isSurveillanceView && urlShowOtherGroundTruthSeasons) {
+      if (showOtherGroundTruthSeasons) {
+        setShowOtherGroundTruthSeasons(false);
+      }
+      urlManager.updateAdvancedParams({
+        showOtherGroundTruthSeasons: false,
+      });
+      return;
+    }
+
     if (urlScale !== chartScale) {
       setChartScale(urlScale);
     }
@@ -825,6 +838,7 @@ export const ViewProvider = ({ children }) => {
     location.pathname,
     urlManager,
     isForecastPage,
+    viewType,
     chartScale,
     intervalVisibility,
     showLegend,

--- a/app/src/contexts/ViewContext.jsx
+++ b/app/src/contexts/ViewContext.jsx
@@ -12,7 +12,6 @@ import {
   isPathBasedForecastView,
   parseForecastUrlState,
 } from "../utils/forecastRoutes";
-import { FLU_PEAK_AVAILABLE_DATE_START } from "../utils/forecastSeasons";
 
 const METRO_STATE_MAP = {
   Colorado: "CO",
@@ -467,9 +466,7 @@ export const ViewProvider = ({ children }) => {
   // filter flu_peak dates based on current season
   const availableDatesToExpose = useMemo(() => {
     if (viewType === "flu_peak") {
-      return (availablePeakDates || []).filter(
-        (date) => date >= FLU_PEAK_AVAILABLE_DATE_START,
-      );
+      return availablePeakDates || [];
     }
     return availableDates || [];
   }, [viewType, availablePeakDates, availableDates]);
@@ -950,9 +947,7 @@ export const ViewProvider = ({ children }) => {
     selectedTarget,
     handleTargetSelect,
     peaks,
-    availablePeakDates: (availablePeakDates || []).filter(
-      (date) => date >= FLU_PEAK_AVAILABLE_DATE_START,
-    ),
+    availablePeakDates: availablePeakDates || [],
     availablePeakModels,
     chartScale,
     setChartScale: setChartScaleWithUrl,

--- a/app/src/contexts/ViewContext.jsx
+++ b/app/src/contexts/ViewContext.jsx
@@ -388,6 +388,8 @@ export const ViewProvider = ({ children }) => {
   const [showLegend, setShowLegend] = useState(
     () => urlManager.getAdvancedParams().showLegend,
   );
+  const [showOtherGroundTruthSeasons, setShowOtherGroundTruthSeasons] =
+    useState(() => urlManager.getAdvancedParams().showOtherGroundTruthSeasons);
   const CURRENT_FLU_SEASON_START = "2025-11-01"; // !! CRITICAL !!: need to change this manually based on the season (for flu peak view)
 
   const {
@@ -807,6 +809,7 @@ export const ViewProvider = ({ children }) => {
       chartScale: urlScale,
       intervalVisibility: urlIntervals,
       showLegend: urlLegend,
+      showOtherGroundTruthSeasons: urlShowOtherGroundTruthSeasons,
     } = urlManager.getAdvancedParams();
     if (urlScale !== chartScale) {
       setChartScale(urlScale);
@@ -817,6 +820,9 @@ export const ViewProvider = ({ children }) => {
     if (urlLegend !== showLegend) {
       setShowLegend(urlLegend);
     }
+    if (urlShowOtherGroundTruthSeasons !== showOtherGroundTruthSeasons) {
+      setShowOtherGroundTruthSeasons(urlShowOtherGroundTruthSeasons);
+    }
   }, [
     searchParams,
     location.pathname,
@@ -825,6 +831,7 @@ export const ViewProvider = ({ children }) => {
     chartScale,
     intervalVisibility,
     showLegend,
+    showOtherGroundTruthSeasons,
   ]);
 
   useEffect(() => {
@@ -879,6 +886,18 @@ export const ViewProvider = ({ children }) => {
       setShowLegend(nextShowLegend);
       if (isForecastPage) {
         urlManager.updateAdvancedParams({ showLegend: nextShowLegend });
+      }
+    },
+    [urlManager, isForecastPage],
+  );
+
+  const setShowOtherGroundTruthSeasonsWithUrl = useCallback(
+    (nextValue) => {
+      setShowOtherGroundTruthSeasons(nextValue);
+      if (isForecastPage) {
+        urlManager.updateAdvancedParams({
+          showOtherGroundTruthSeasons: nextValue,
+        });
       }
     },
     [urlManager, isForecastPage],
@@ -941,6 +960,8 @@ export const ViewProvider = ({ children }) => {
     setIntervalVisibility: setIntervalVisibilityWithUrl,
     showLegend,
     setShowLegend: setShowLegendWithUrl,
+    showOtherGroundTruthSeasons,
+    setShowOtherGroundTruthSeasons: setShowOtherGroundTruthSeasonsWithUrl,
   };
 
   return (

--- a/app/src/hooks/useForecastleScenario.js
+++ b/app/src/hooks/useForecastleScenario.js
@@ -236,12 +236,12 @@ const ensureValidScenario = async (rng, datasetMeta) => {
       FORECASTLE_CONFIG.historyDisplay.default;
 
     if (historyConfig === "seasonStart") {
-      // Show since start of season (approximately July 1st)
+      // Show since start of season (September 1st)
       const forecastDateObj = new Date(forecastDate);
       const year = forecastDateObj.getFullYear();
-      // If we're in Jan-Jun, season started previous year
-      const seasonStartYear = forecastDateObj.getMonth() < 6 ? year - 1 : year;
-      const seasonStart = new Date(`${seasonStartYear}-07-01`).getTime();
+      // If we're before September, season started the previous year
+      const seasonStartYear = forecastDateObj.getMonth() < 8 ? year - 1 : year;
+      const seasonStart = new Date(`${seasonStartYear}-09-01`).getTime();
 
       recentSeries = historicalSeries.filter((entry) => {
         const entryTime = new Date(entry.date).getTime();

--- a/app/src/hooks/useQuantileForecastTraces.js
+++ b/app/src/hooks/useQuantileForecastTraces.js
@@ -149,7 +149,6 @@ const useQuantileForecastTraces = ({
   groundTruthHoverFormatter = null,
   baselineModelName = null,
   showOtherGroundTruthSeasons = false,
-  viewType = null,
 }) => {
   const stableModelOrderRef = useRef([]);
   const stableModelOrder = useMemo(() => {
@@ -474,7 +473,6 @@ const useQuantileForecastTraces = ({
       ? buildHistoricalGroundTruthTraces({
           groundTruth,
           target,
-          viewType,
           transformY,
           groundTruthLineWidth,
           groundTruthHoverFormatter,
@@ -523,7 +521,6 @@ const useQuantileForecastTraces = ({
     baselineModelName,
     stableModelOrder,
     showOtherGroundTruthSeasons,
-    viewType,
   ]);
 };
 

--- a/app/src/hooks/useQuantileForecastTraces.js
+++ b/app/src/hooks/useQuantileForecastTraces.js
@@ -2,6 +2,7 @@ import { useMemo, useRef } from "react";
 import { MODEL_COLORS, getModelColor } from "../config/datasets";
 import { extendStableModelOrder } from "../utils/modelColorUtils";
 import { calculateRelativeWIS, calculateWIS } from "../utils/forecastleScoring";
+import { buildHistoricalGroundTruthTraces } from "../utils/forecastSeasons";
 
 const defaultFormatValue = (value) =>
   value.toLocaleString(undefined, { maximumFractionDigits: 2 });
@@ -147,6 +148,8 @@ const useQuantileForecastTraces = ({
   transformY = null,
   groundTruthHoverFormatter = null,
   baselineModelName = null,
+  showOtherGroundTruthSeasons = false,
+  viewType = null,
 }) => {
   const stableModelOrderRef = useRef([]);
   const stableModelOrder = useMemo(() => {
@@ -160,13 +163,13 @@ const useQuantileForecastTraces = ({
 
   return useMemo(() => {
     if (!groundTruth || !forecasts || selectedDates.length === 0 || !target) {
-      return { traces: [], rawYRange: null };
+      return { traces: [], rawYRange: null, hasForecastTraces: false };
     }
 
     const groundTruthValues = groundTruth[target];
     if (!groundTruthValues) {
       console.warn(`Ground truth data not found for target: ${target}`);
-      return { traces: [], rawYRange: null };
+      return { traces: [], rawYRange: null, hasForecastTraces: false };
     }
 
     let rawMin = Infinity;
@@ -467,10 +470,30 @@ const useQuantileForecastTraces = ({
       }),
     );
 
+    const historicalGroundTruthTraces = showOtherGroundTruthSeasons
+      ? buildHistoricalGroundTruthTraces({
+          groundTruth,
+          target,
+          viewType,
+          transformY,
+          groundTruthLineWidth,
+          groundTruthHoverFormatter,
+          valueSuffix,
+        })
+      : [];
+
     const rawYRange =
       rawMin === Infinity || rawMax === -Infinity ? null : [rawMin, rawMax];
 
-    return { traces: [groundTruthTrace, ...modelTraces], rawYRange };
+    return {
+      traces: [
+        groundTruthTrace,
+        ...historicalGroundTruthTraces,
+        ...modelTraces,
+      ],
+      rawYRange,
+      hasForecastTraces: modelTraces.length > 0,
+    };
   }, [
     groundTruth,
     forecasts,
@@ -497,7 +520,10 @@ const useQuantileForecastTraces = ({
     intervalVisibility,
     transformY,
     groundTruthHoverFormatter,
+    baselineModelName,
     stableModelOrder,
+    showOtherGroundTruthSeasons,
+    viewType,
   ]);
 };
 

--- a/app/src/utils/forecastSeasons.js
+++ b/app/src/utils/forecastSeasons.js
@@ -1,5 +1,6 @@
 const SEASON_START_MONTH_INDEX = 8;
 const SEASON_START_DAY = 1;
+const PEAK_SEASON_START_MONTH_INDEX = 7;
 
 const HUB_SEASON_START_BY_VIEW = {
   flu_forecasts: "2022-09-01",
@@ -8,6 +9,10 @@ const HUB_SEASON_START_BY_VIEW = {
   covid_forecasts: "2022-09-01",
   metrocast_forecasts: "2022-09-01",
 };
+
+export const FLU_PEAK_AVAILABLE_DATE_START = "2025-11-01";
+export const FLU_PEAK_GROUND_TRUTH_START = "2025-08-01";
+export const FLU_PEAK_NORMALIZED_X_RANGE = ["2000-08-01", "2001-05-31"];
 
 const padNumber = (value) => String(value).padStart(2, "0");
 
@@ -43,6 +48,14 @@ export const alignDateToSeason = (dateString, anchorSeasonStartYear) => {
       : anchorSeasonStartYear + 1;
 
   return new Date(Date.UTC(alignedYear, month, day)).toISOString().slice(0, 10);
+};
+
+export const getNormalizedPeakDate = (dateString) => {
+  const date = toUtcDate(dateString);
+  const baseYear =
+    date.getUTCMonth() >= PEAK_SEASON_START_MONTH_INDEX ? 2000 : 2001;
+  date.setUTCFullYear(baseYear);
+  return date;
 };
 
 export const buildHistoricalGroundTruthTraces = ({

--- a/app/src/utils/forecastSeasons.js
+++ b/app/src/utils/forecastSeasons.js
@@ -1,0 +1,142 @@
+const SEASON_START_MONTH_INDEX = 8;
+const SEASON_START_DAY = 1;
+
+const HUB_SEASON_START_BY_VIEW = {
+  flu_forecasts: "2022-09-01",
+  fludetailed: "2022-09-01",
+  rsv_forecasts: "2022-09-01",
+  covid_forecasts: "2022-09-01",
+  metrocast_forecasts: "2022-09-01",
+};
+
+const padNumber = (value) => String(value).padStart(2, "0");
+
+const toUtcDate = (dateString) => {
+  const [year, month, day] = String(dateString).split("-").map(Number);
+  return new Date(Date.UTC(year, month - 1, day));
+};
+
+export const getHubSeasonStartDate = (viewType) =>
+  HUB_SEASON_START_BY_VIEW[viewType] || null;
+
+export const getSeasonStartYear = (dateString) => {
+  const date = toUtcDate(dateString);
+  const year = date.getUTCFullYear();
+  return date.getUTCMonth() >= SEASON_START_MONTH_INDEX ? year : year - 1;
+};
+
+export const getSeasonKeyFromStartYear = (seasonStartYear) =>
+  `${seasonStartYear}-${seasonStartYear + 1}`;
+
+export const getSeasonDateRange = (seasonStartYear) => ({
+  start: `${seasonStartYear}-${padNumber(SEASON_START_MONTH_INDEX + 1)}-${padNumber(SEASON_START_DAY)}`,
+  end: `${seasonStartYear + 1}-${padNumber(SEASON_START_MONTH_INDEX + 1)}-${padNumber(SEASON_START_DAY)}`,
+});
+
+export const alignDateToSeason = (dateString, anchorSeasonStartYear) => {
+  const date = toUtcDate(dateString);
+  const month = date.getUTCMonth();
+  const day = date.getUTCDate();
+  const alignedYear =
+    month >= SEASON_START_MONTH_INDEX
+      ? anchorSeasonStartYear
+      : anchorSeasonStartYear + 1;
+
+  return new Date(Date.UTC(alignedYear, month, day)).toISOString().slice(0, 10);
+};
+
+export const buildHistoricalGroundTruthTraces = ({
+  groundTruth,
+  target,
+  viewType,
+  transformY,
+  groundTruthLineWidth = 1.5,
+  groundTruthHoverFormatter = null,
+  valueSuffix = "",
+}) => {
+  const hubSeasonStartDate = getHubSeasonStartDate(viewType);
+  const groundTruthDates = groundTruth?.dates || [];
+  const groundTruthValues = groundTruth?.[target] || [];
+
+  if (
+    !hubSeasonStartDate ||
+    !groundTruthDates.length ||
+    !groundTruthValues.length
+  ) {
+    return [];
+  }
+
+  const seasons = new Map();
+
+  groundTruthDates.forEach((dateString, index) => {
+    if (dateString < hubSeasonStartDate) {
+      return;
+    }
+
+    const value = groundTruthValues[index];
+    if (value === null || value === undefined || Number.isNaN(Number(value))) {
+      return;
+    }
+
+    const seasonStartYear = getSeasonStartYear(dateString);
+    if (!seasons.has(seasonStartYear)) {
+      seasons.set(seasonStartYear, []);
+    }
+
+    seasons.get(seasonStartYear).push({
+      actualDate: dateString,
+      value,
+    });
+  });
+
+  const seasonStartYears = Array.from(seasons.keys()).sort((a, b) => a - b);
+  if (seasonStartYears.length <= 1) {
+    return [];
+  }
+
+  const traces = [];
+  let showLegend = true;
+
+  seasonStartYears.forEach((anchorSeasonStartYear) => {
+    seasonStartYears.forEach((sourceSeasonStartYear) => {
+      if (anchorSeasonStartYear === sourceSeasonStartYear) {
+        return;
+      }
+
+      const sourcePoints = seasons.get(sourceSeasonStartYear) || [];
+      const rawY = sourcePoints.map((point) => point.value);
+
+      traces.push({
+        x: sourcePoints.map((point) =>
+          alignDateToSeason(point.actualDate, anchorSeasonStartYear),
+        ),
+        y: transformY ? rawY.map((value) => transformY(value)) : rawY,
+        type: "scatter",
+        mode: "lines",
+        name: "Historical Seasons",
+        legendgroup: "historical-ground-truth",
+        showlegend: showLegend,
+        line: {
+          color: "#d3d3d3",
+          width: groundTruthLineWidth,
+        },
+        customdata: sourcePoints.map((point, index) => [
+          point.actualDate,
+          getSeasonKeyFromStartYear(sourceSeasonStartYear),
+          groundTruthHoverFormatter
+            ? groundTruthHoverFormatter(rawY[index])
+            : rawY[index],
+        ]),
+        hovertemplate:
+          "<b>Historical season</b><br>" +
+          "Source season: %{customdata[1]}<br>" +
+          "Original date: %{customdata[0]}<br>" +
+          `Value: <b>%{customdata[2]}${valueSuffix}</b><extra></extra>`,
+      });
+
+      showLegend = false;
+    });
+  });
+
+  return traces;
+};

--- a/app/src/utils/forecastSeasons.js
+++ b/app/src/utils/forecastSeasons.js
@@ -2,14 +2,6 @@ const SEASON_START_MONTH_INDEX = 8;
 const SEASON_START_DAY = 1;
 const PEAK_SEASON_START_MONTH_INDEX = 7;
 
-const HUB_SEASON_START_BY_VIEW = {
-  flu_forecasts: "2022-09-01",
-  fludetailed: "2022-09-01",
-  rsv_forecasts: "2022-09-01",
-  covid_forecasts: "2022-09-01",
-  metrocast_forecasts: "2022-09-01",
-};
-
 export const FLU_PEAK_AVAILABLE_DATE_START = "2025-11-01";
 export const FLU_PEAK_GROUND_TRUTH_START = "2025-08-01";
 export const FLU_PEAK_NORMALIZED_X_RANGE = ["2000-08-01", "2001-05-31"];
@@ -20,9 +12,6 @@ const toUtcDate = (dateString) => {
   const [year, month, day] = String(dateString).split("-").map(Number);
   return new Date(Date.UTC(year, month - 1, day));
 };
-
-export const getHubSeasonStartDate = (viewType) =>
-  HUB_SEASON_START_BY_VIEW[viewType] || null;
 
 export const getSeasonStartYear = (dateString) => {
   const date = toUtcDate(dateString);
@@ -37,6 +26,11 @@ export const getSeasonDateRange = (seasonStartYear) => ({
   start: `${seasonStartYear}-${padNumber(SEASON_START_MONTH_INDEX + 1)}-${padNumber(SEASON_START_DAY)}`,
   end: `${seasonStartYear + 1}-${padNumber(SEASON_START_MONTH_INDEX + 1)}-${padNumber(SEASON_START_DAY)}`,
 });
+
+export const getSeasonStartDateForDate = (dateString) => {
+  const seasonStartYear = getSeasonStartYear(dateString);
+  return `${seasonStartYear}-${padNumber(SEASON_START_MONTH_INDEX + 1)}-${padNumber(SEASON_START_DAY)}`;
+};
 
 export const alignDateToSeason = (dateString, anchorSeasonStartYear) => {
   const date = toUtcDate(dateString);
@@ -58,16 +52,35 @@ export const getNormalizedPeakDate = (dateString) => {
   return date;
 };
 
+export const getEarliestGroundTruthSeasonStartDate = ({
+  groundTruth,
+  target,
+}) => {
+  const groundTruthDates = groundTruth?.dates || [];
+  const groundTruthValues = groundTruth?.[target] || [];
+
+  const earliestDate = groundTruthDates.find((dateString, index) => {
+    const value = groundTruthValues[index];
+    return (
+      value !== null && value !== undefined && !Number.isNaN(Number(value))
+    );
+  });
+
+  return earliestDate ? getSeasonStartDateForDate(earliestDate) : null;
+};
+
 export const buildHistoricalGroundTruthTraces = ({
   groundTruth,
   target,
-  viewType,
   transformY,
   groundTruthLineWidth = 1.5,
   groundTruthHoverFormatter = null,
   valueSuffix = "",
 }) => {
-  const hubSeasonStartDate = getHubSeasonStartDate(viewType);
+  const hubSeasonStartDate = getEarliestGroundTruthSeasonStartDate({
+    groundTruth,
+    target,
+  });
   const groundTruthDates = groundTruth?.dates || [];
   const groundTruthValues = groundTruth?.[target] || [];
 

--- a/app/src/utils/urlManager.js
+++ b/app/src/utils/urlManager.js
@@ -7,6 +7,7 @@ const DEFAULT_INTERVAL_VISIBILITY = {
   ci95: true,
 };
 const DEFAULT_SHOW_LEGEND = true;
+const DEFAULT_SHOW_OTHER_GT = false;
 
 export class URLParameterManager {
   constructor(
@@ -70,6 +71,7 @@ export class URLParameterManager {
     const scaleParam = this.searchParams.get("scale");
     const intervalsParam = this.searchParams.get("intervals");
     const legendParam = this.searchParams.get("legend");
+    const otherGtParam = this.searchParams.get("other_gt");
 
     const chartScale = normalizeChartScale(scaleParam || DEFAULT_CHART_SCALE);
     let intervalVisibility = { ...DEFAULT_INTERVAL_VISIBILITY };
@@ -96,7 +98,19 @@ export class URLParameterManager {
       showLegend = true;
     }
 
-    return { chartScale, intervalVisibility, showLegend };
+    let showOtherGroundTruthSeasons = DEFAULT_SHOW_OTHER_GT;
+    if (otherGtParam === "1" || otherGtParam === "true") {
+      showOtherGroundTruthSeasons = true;
+    } else if (otherGtParam === "0" || otherGtParam === "false") {
+      showOtherGroundTruthSeasons = false;
+    }
+
+    return {
+      chartScale,
+      intervalVisibility,
+      showLegend,
+      showOtherGroundTruthSeasons,
+    };
   }
 
   // Clear parameters for a specific dataset
@@ -123,7 +137,12 @@ export class URLParameterManager {
     this.setSearchParams(newParams, { replace: true });
   }
 
-  updateAdvancedParams({ chartScale, intervalVisibility, showLegend }) {
+  updateAdvancedParams({
+    chartScale,
+    intervalVisibility,
+    showLegend,
+    showOtherGroundTruthSeasons,
+  }) {
     const updatedParams = new URLSearchParams(this.searchParams);
 
     if (chartScale) {
@@ -152,6 +171,14 @@ export class URLParameterManager {
         updatedParams.set("legend", showLegend ? "1" : "0");
       } else {
         updatedParams.delete("legend");
+      }
+    }
+
+    if (typeof showOtherGroundTruthSeasons === "boolean") {
+      if (showOtherGroundTruthSeasons !== DEFAULT_SHOW_OTHER_GT) {
+        updatedParams.set("other_gt", showOtherGroundTruthSeasons ? "1" : "0");
+      } else {
+        updatedParams.delete("other_gt");
       }
     }
 


### PR DESCRIPTION
- maintain continuous plots but allow for non-current gt curves to be shown on the plot (toggled with a switch in the advanced controls). **uses hard-coded season start dates of sept. 1**
    - remove other hard-coded season start/ends (don't need them anymore, and they were scattered/conflicting anyways)
- conform flu peak view to this style of continuous plot with optional non-current gt curves
- disable the `other gt` switch for surveillance views