### PR TITLE
Bug fixes!

### DIFF
--- a/app/src/components/NHSNOverviewGraph.jsx
+++ b/app/src/components/NHSNOverviewGraph.jsx
@@ -18,13 +18,17 @@ const PATHOGEN_COLORS = {
 };
 
 const NHSNOverviewGraph = ({ location }) => {
-  const { setViewType, viewType: activeViewType } = useView();
+  const {
+    setViewAndLocation,
+    viewType: activeViewType,
+    selectedLocation,
+  } = useView();
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
   const resolvedLocation = location || "US";
-  const isActive = activeViewType === "nhsn";
+  const isActive = activeViewType === "nhsnall";
 
   useEffect(() => {
     const fetchData = async () => {
@@ -146,6 +150,8 @@ const NHSNOverviewGraph = ({ location }) => {
 
   const locationLabel =
     resolvedLocation === "US" ? "US national view" : resolvedLocation;
+  const nhsnViewLocation =
+    selectedLocation && selectedLocation !== "US_All" ? resolvedLocation : "US";
 
   return (
     <OverviewGraphCard
@@ -159,7 +165,7 @@ const NHSNOverviewGraph = ({ location }) => {
       emptyLabel={null}
       actionLabel={isActive ? "Viewing" : "View NHSN data"}
       actionActive={isActive}
-      onAction={() => setViewType("nhsn")}
+      onAction={() => setViewAndLocation("nhsnall", nhsnViewLocation)}
       actionIcon={<IconChevronRight size={14} />}
       locationLabel={locationLabel}
     />

--- a/scripts/nhsn_data_processor.py
+++ b/scripts/nhsn_data_processor.py
@@ -55,13 +55,18 @@ class NHSNDataProcessor:
 
         # pre-processing check:
         # ensure same loc and weekendingdate set between the two
+        # locs
         unique_regions = set(data['jurisdiction'])
         preliminary_unique_regions = set(preliminary_data['jurisdiction'])
-        if region_diff := unique_regions ^ preliminary_unique_regions:
+        if missing_regions := (unique_regions - preliminary_unique_regions):
             raise ValueError(
-                "Detected a difference between NHSN regular data locs and NHSN prelim data locs: "
-                f"{region_diff}.\nLen regular locs: {len(unique_regions)}\nLen prelim locs: {len(preliminary_unique_regions)}"
+                f"Data contains jurisdictions not present in preliminary data: {missing_regions}"
             )
+        if preliminary_unique_regions - unique_regions:
+            preliminary_data = preliminary_data[
+                preliminary_data['jurisdiction'].isin(unique_regions)
+            ].copy()
+        # dates
         unique_dates = set(data['weekendingdate'])
         preliminary_unique_dates = set(preliminary_data['weekendingdate'])
         if missing_from_prelim := (unique_dates - preliminary_unique_dates): # fail if prelim is missing any, or the two are lopsided 

--- a/scripts/nhsn_data_processor.py
+++ b/scripts/nhsn_data_processor.py
@@ -64,11 +64,14 @@ class NHSNDataProcessor:
             )
         unique_dates = set(data['weekendingdate'])
         preliminary_unique_dates = set(preliminary_data['weekendingdate'])
-        if date_diff := unique_dates ^ preliminary_unique_dates:
+        if missing_from_prelim := (unique_dates - preliminary_unique_dates): # fail if prelim is missing any, or the two are lopsided 
             raise ValueError(
-                "Detected a difference between NHSN regular data weekendingdates and NHSN prelim "
-                f"data weekendingdates: {date_diff}"
+                f"Data contains dates not present in preliminary data: {missing_from_prelim}"
             )
+        if (preliminary_unique_dates - unique_dates): # limit if just prelim has extra dates (this will often be the case as prelim releases new dates earlier)
+            preliminary_data = preliminary_data[
+                preliminary_data['weekendingdate'].isin(unique_dates)
+            ].copy()
 
         # Process the data
         # Pipeline #1: key on longform location column name


### PR DESCRIPTION
-  A more nuanced `jurisdiction` and `weekendingdate` validation system between regular NHSN data and preliminary NHSN data
    - Before, the code was failing if there was any discrepancy in location and date sets between the two datasets. Now, if extra stuff is found in prelim data it is filtered down to only contain what is in regular data. If prelim has more (i.e., there is an unfixable difference between the two), it fails. 
- Clicking the NHSN overview plot on the landing page now takes you to the correct URL (was using the old one before) 